### PR TITLE
Change axisbg to facecolor in matplotlib commands

### DIFF
--- a/zrad/texture.py
+++ b/zrad/texture.py
@@ -2252,7 +2252,7 @@ class Texture(object):
             fig = py.figure(20, figsize = (20,20))
             fig.text(0.5, 0.95, ImName+' '+name)
             for j in arange(0, 24):
-                axes = fig.add_subplot(5, 5, j+1, axisbg='#FFFF99')
+                axes = fig.add_subplot(5, 5, j+1, facecolor='#FFFF99')
                 axes.set_title(24*n+j)
                 try:
                     im = axes.imshow(matrix[24*n+j], cmap=py.cm.Greys_r, vmin = 0, vmax = self.n_bits)

--- a/zrad/texture_phantom.py
+++ b/zrad/texture_phantom.py
@@ -2152,7 +2152,7 @@ class Texture(object):
             fig = py.figure(20, figsize = (20,20))
             fig.text(0.5, 0.95, ImName+' '+name)
             for j in arange(0, 24):
-                axes = fig.add_subplot(5, 5, j+1, axisbg='#FFFF99')
+                axes = fig.add_subplot(5, 5, j+1, facecolor='#FFFF99')
                 axes.set_title(24*n+j)
                 try:
                     im = axes.imshow(matrix[24*n+j], cmap=py.cm.Greys_r, vmin = 0, vmax = self.n_bits)


### PR DESCRIPTION
**axisbg** has been deprecated since matplotlib v.2.0.0. **facecolor** should be used instead.

Use of **axisbg** results in a _DeprecationWarning_ for matplotlib v2+. For matplotlib v3+, it results in an _AttributeError_.