### PR TITLE
Bugfix for numpy setprintoptions

### DIFF
--- a/zrad/shape.py
+++ b/zrad/shape.py
@@ -48,8 +48,6 @@ class Shape(object):
         del ind_f
         del path_set
 
-        np.set_printoptions(threshold='nan')
-
         #calculate parameters of all GTVs
         if exists(path_results):
             remove(path_results)


### PR DESCRIPTION
`np.set_printoptions(threshold='nan')` in **shape.py** (line 51) raises an error with Numpy v.1.16 (`ValueError("threshold must be numeric and non-NAN)`).

It seems like a nonstandard argument as the threshold parameter expects either `None `or `int`. https://docs.scipy.org/doc/numpy/reference/generated/numpy.set_printoptions.html

I deleted the line.