### PR TITLE
Empty contour slices introduced in low resolutions due to rounding precision.

### DIFF
--- a/zrad/structure.py
+++ b/zrad/structure.py
@@ -78,12 +78,12 @@ class Structures(object):
                                 self.logger.info('z positions image \n' + ", ".join(map(str,self.slices)))
                                 slice_count = True #True is more than one slice
                                 try:
-                                    diffI = round(index[1]-index[0], 1) #double check if the orientation is ok
+                                    diffI = round(index[1]-index[0], 2)  # double check if the orientation is ok
                                 except IndexError:
                                     info = 'only one slice'
                                     slice_count = False
-                                if slice_count: #if more than one slice
-                                    diffS = round(self.slices[1]-self.slices[0],1)
+                                if slice_count:  # if more than one slice
+                                    diffS = round(self.slices[1]-self.slices[0], 2)
                                     self.logger.info("resolution image, ROI " + ", ".join(map(str, (diffI, diffS))))
                                     if np.sign(diffI) != np.sign(diffS): #if different orientation then reverse the contour points
                                         index.reverse()


### PR DESCRIPTION
**Explanation**
`Structures.find()` function inserts empty slices to the contour data even though it should not. This happens only for resolution of 0.15 or 0.05. I increased the rounding precision to fix this.

**How to reproduce the error:**
**1. Resizing**
Original data: `K:\RAO_Physik\Research\1_FUNCTIONAL IMAGING\8_LungFibroses\1_data\mice_new\4_dcm_fixed_hu\`
Structure name: `lunge`
Resolution: `0.15`
Start: `100`
Stop: `100`
Resize structure: `Yes`
Resize shape: `No`

**2. Feature extraction**
Structure name: `lunge`
Bin size: `50`
Dimension: `3D`
Wavelet transform: `On`
Shape: `Off`
Lymph nodes: `off`
HU limits: `none`
