### PR TITLE
Bug in NGLDM matrix?

### DIFF
--- a/zrad/texture.py
+++ b/zrad/texture.py
@@ -2080,7 +2080,7 @@ class Texture(object):
         return e
 
     def NGLDM(self, matrix):  # Oncoray 4.2
-        '''neighborhood gray-level dependence matrix'''
+        """Calculate neighborhood gray-level dependence matrix"""
         s = []
         for i in arange(0, self.n_bits):
             s.append([0])
@@ -2126,7 +2126,7 @@ class Texture(object):
                             for gray in arange(0, len(s)):
                                 for app in arange(maxSize, size):
                                     s[gray].append(0)
-                            maxSize = size      # actualize maxSize
+                            maxSize = size  # update maxSize
                         s[int(v)][size] += 1
                        
 


### PR DESCRIPTION
I added a line to update the maxSize. 
As I understand it, the NGLDM matrix should have a maximal size of 26 or 9 on axis 1 (depending on the 3d or 2d neighbourhood). Without this line, axis 1 will be too long.