### PR TITLE
Exclude non-axial images from resizing

### DIFF
--- a/zrad/resize_shape.py
+++ b/zrad/resize_shape.py
@@ -86,12 +86,15 @@ class ResizeShape(object):
                 onlyfiles = []
                 for f in listdir(mypath_file):
                     try:
+                        ds = dc.read_file(mypath_file + f)
                         # read only dicoms of certain modality
-                        if isfile(join(mypath_file, f)) and dc.read_file(mypath_file + f).SOPClassUID in UID_t:
+                        if isfile(join(mypath_file, f)) and ds.SOPClassUID in UID_t:
+                            # skip non-axial slices
+                            is_axial = np.array_equal(np.round(ds.ImageOrientationPatient), [1, 0, 0, 0, 1, 0])
+                            if (self.image_type == 'CT') and not is_axial:
+                                continue
                             # sort files by slice position
-                            onlyfiles.append((round(
-                                float(dc.read_file(mypath_file + os.sep + f).ImagePositionPatient[2]),
-                                self.round_factor), f))
+                            onlyfiles.append((round(float(ds.ImagePositionPatient[2]), self.round_factor), f))
                     except InvalidDicomError:  # not a dicom file
                         dcm_problems_this.append(name + '   ' + f)
                         pass

--- a/zrad/resize_texture.py
+++ b/zrad/resize_texture.py
@@ -98,12 +98,15 @@ class ResizeTexture(object):
 
                     for f in listdir(mypath_file):
                         try:
+                            ds = dc.read_file(mypath_file + f)
                             # read only dicoms of certain modality
-                            if isfile(join(mypath_file, f)) and dc.read_file(mypath_file + f).SOPClassUID in UID_t:
+                            if isfile(join(mypath_file, f)) and ds.SOPClassUID in UID_t:
+                                # skip non-axial slices
+                                is_axial = np.array_equal(np.round(ds.ImageOrientationPatient), [1, 0, 0, 0, 1, 0])
+                                if (self.image_type == 'CT') and not is_axial:
+                                    continue
                                 # sort files by slice position
-                                onlyfiles.append((round(
-                                    float(dc.read_file(mypath_file + os.sep + f).ImagePositionPatient[2]),
-                                    self.round_factor), f))
+                                onlyfiles.append((round(float(ds.ImagePositionPatient[2]), self.round_factor), f))
                         except InvalidDicomError:  # not a dicom file
                             self.listDicomProblem.append(name + ' ' + f)
                             pass


### PR DESCRIPTION
Some CT series provide one coronal image apart from a series of axial images. This either produces an error during resizing or, even worse, interpolates the coronal image together with axial images.

This PR makes Z-Rad skip non-axial images during resizing and interpolates only axial slices.