### PR TITLE
Refactoring to simplify the API 

### DIFF
--- a/zrad/__init__.py
+++ b/zrad/__init__.py
@@ -1,1 +1,5 @@
 __version__ = "24.10"
+from .logic import Preprocessing
+from .logic import Filtering
+from .logic import Radiomics
+from .logic import Image

--- a/zrad/logic/__init__.py
+++ b/zrad/logic/__init__.py
@@ -1,2 +1,4 @@
 from .preprocessing import Preprocessing
+from .filtering import Filtering
 from .radiomics import Radiomics
+from .image import Image


### PR DESCRIPTION
Now we can simply call from zrad import Radiomics instead of from zrad.logic.radiomics import Radiomics