### PR TITLE
If no RTstruct file present set input_params['rtstruct_path'] = None

### DIFF
--- a/zrad/gui/prep_tab.py
+++ b/zrad/gui/prep_tab.py
@@ -54,6 +54,8 @@ def process_patient_folder(input_params, patient_folder, structure_set):
             input_params['rtstruct_path'] = rtstruct_paths[0]['file_path']
             if input_params["use_all_structures"]:
                 structure_set = get_all_structure_names(input_params['rtstruct_path'])
+        else:
+            input_params['rtstruct_path'] = None
 
     if structure_set:
         mask_union = None


### PR DESCRIPTION
Previously, if two folders were processed and the first contained an RTstruct while the second did not, the RTstruct from the first folder was mistakenly used for both. Now, if no RTstruct is present in a folder, the corresponding file path is correctly set to None.