### PR TITLE
ENH Handle RTSTRUCT contours outside target image bounds

### DIFF
--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pydicom
 import pytest
@@ -7,7 +9,7 @@ from pydicom.sequence import Sequence
 from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 
 import zrad.io.dicom as dicom
-from zrad.exceptions import DataStructureError, DataStructureWarning
+from zrad.exceptions import DataStructureWarning
 
 
 def _make_sitk_image(size=(5, 5, 3), frame_uid="1.2.826.0.1.3680043.8.498.1"):
@@ -165,26 +167,17 @@ def test_extract_dicom_mask_returns_empty_image_when_roi_has_no_target_fov_overl
 
 
 @pytest.mark.unit
-def test_rtstruct_matching_frame_of_reference_uid_passes():
-    image = _make_sitk_image(frame_uid="1.2.3")
+def test_extract_dicom_mask_does_not_validate_frame_of_reference_uid(tmp_path):
+    rtstruct_path = tmp_path / "rtstruct.dcm"
+    _write_rtstruct(rtstruct_path, "GTV", "1.2.826.0.1.3680043.8.498.5", [_square_contour()])
+    image = _make_sitk_image(frame_uid="1.2.826.0.1.3680043.8.498.6")
 
-    dicom._validate_rtstruct_frame_of_reference({"referenced_frame": "1.2.3"}, image, "GTV")
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
 
-
-@pytest.mark.unit
-def test_rtstruct_mismatched_frame_of_reference_uid_raises():
-    image = _make_sitk_image(frame_uid="1.2.3")
-
-    with pytest.raises(DataStructureError, match="FrameOfReferenceUID"):
-        dicom._validate_rtstruct_frame_of_reference({"referenced_frame": "4.5.6"}, image, "GTV")
-
-
-@pytest.mark.unit
-def test_rtstruct_missing_frame_of_reference_uid_warns_and_continues():
-    image = _make_sitk_image(frame_uid=None)
-
-    with pytest.warns(DataStructureWarning, match="could not be verified"):
-        dicom._validate_rtstruct_frame_of_reference({"referenced_frame": "1.2.3"}, image, "GTV")
+    assert mask.array is not None
+    assert mask.array.any()
+    assert not any(issubclass(warning.category, DataStructureWarning) for warning in caught_warnings)
 
 
 @pytest.mark.unit

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -66,11 +66,7 @@ def _write_rtstruct(path, roi_name, contours):
         contour_ds.ContourGeometricType = contour["type"]
         points = contour["points"]
         contour_ds.NumberOfContourPoints = len(points["x"])
-        contour_ds.ContourData = [
-            value
-            for point in zip(points["x"], points["y"], points["z"])
-            for value in point
-        ]
+        contour_ds.ContourData = [value for point in zip(points["x"], points["y"], points["z"]) for value in point]
         roi_contour.ContourSequence.append(contour_ds)
     ds.ROIContourSequence = Sequence([roi_contour])
 
@@ -155,4 +151,3 @@ def test_extract_dicom_mask_returns_empty_image_when_roi_has_no_target_fov_overl
         mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
 
     assert mask.array is None
-

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,0 +1,219 @@
+import numpy as np
+import pydicom
+import pytest
+import SimpleITK as sitk
+from pydicom.dataset import Dataset, FileDataset, FileMetaDataset
+from pydicom.sequence import Sequence
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
+
+import zrad.io.dicom as dicom
+from zrad.exceptions import DataStructureError, DataStructureWarning
+
+
+def _make_sitk_image(size=(5, 5, 3), frame_uid="1.2.826.0.1.3680043.8.498.1"):
+    width, height, depth = size
+    image = sitk.GetImageFromArray(np.zeros((depth, height, width), dtype=np.int16))
+    image.SetOrigin((0.0, 0.0, 0.0))
+    image.SetSpacing((1.0, 1.0, 1.0))
+    image.SetDirection((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+    if frame_uid is not None:
+        image.SetMetaData(dicom.FRAME_OF_REFERENCE_UID_KEY, frame_uid)
+        image.SetMetaData(dicom.FRAME_OF_REFERENCE_UID_NAME, frame_uid)
+    return image
+
+
+def _contour(x, y, z, contour_type="CLOSED_PLANAR"):
+    return {
+        "type": contour_type,
+        "points": {
+            "x": x,
+            "y": y,
+            "z": z,
+        },
+    }
+
+
+def _square_contour(z=1.0, contour_type="CLOSED_PLANAR"):
+    return _contour(
+        x=[1.0, 3.0, 3.0, 1.0],
+        y=[1.0, 1.0, 3.0, 3.0],
+        z=[z, z, z, z],
+        contour_type=contour_type,
+    )
+
+
+def _write_rtstruct(path, roi_name, frame_uid, contours):
+    file_meta = FileMetaDataset()
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+    file_meta.MediaStorageSOPClassUID = generate_uid()
+    file_meta.MediaStorageSOPInstanceUID = generate_uid()
+    file_meta.ImplementationClassUID = generate_uid()
+
+    ds = FileDataset(str(path), {}, file_meta=file_meta, preamble=b"\0" * 128)
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+    ds.Modality = "RTSTRUCT"
+    ds.SOPClassUID = file_meta.MediaStorageSOPClassUID
+    ds.SOPInstanceUID = file_meta.MediaStorageSOPInstanceUID
+
+    structure = Dataset()
+    structure.ROINumber = 1
+    structure.ROIName = roi_name
+    if frame_uid is not None:
+        structure.ReferencedFrameOfReferenceUID = frame_uid
+    ds.StructureSetROISequence = Sequence([structure])
+
+    roi_contour = Dataset()
+    roi_contour.ReferencedROINumber = 1
+    roi_contour.ContourSequence = Sequence()
+    for contour in contours:
+        contour_ds = Dataset()
+        contour_ds.ContourGeometricType = contour["type"]
+        points = contour["points"]
+        contour_ds.NumberOfContourPoints = len(points["x"])
+        contour_ds.ContourData = [
+            value
+            for point in zip(points["x"], points["y"], points["z"])
+            for value in point
+        ]
+        roi_contour.ContourSequence.append(contour_ds)
+    ds.ROIContourSequence = Sequence([roi_contour])
+
+    pydicom.dcmwrite(path, ds, write_like_original=False)
+
+
+@pytest.mark.unit
+def test_rtstruct_mask_rasterizes_contour_inside_target_image():
+    image = _make_sitk_image()
+
+    mask, skipped, supported = dicom._generate_rtstruct_mask_array([_square_contour()], image)
+
+    assert supported == 1
+    assert skipped == 0
+    assert mask.shape == (3, 5, 5)
+    assert mask[1].any()
+    assert not mask[0].any()
+    assert not mask[2].any()
+
+
+@pytest.mark.unit
+def test_rtstruct_mask_clips_in_plane_contour_to_target_image():
+    image = _make_sitk_image()
+    contour = _contour(
+        x=[-2.0, 2.0, 2.0, -2.0],
+        y=[-2.0, -2.0, 2.0, 2.0],
+        z=[1.0, 1.0, 1.0, 1.0],
+    )
+
+    mask, skipped, supported = dicom._generate_rtstruct_mask_array([contour], image)
+
+    assert supported == 1
+    assert skipped == 0
+    assert mask[1].any()
+
+
+@pytest.mark.unit
+def test_rtstruct_mask_skips_contour_outside_target_z_without_index_error():
+    image = _make_sitk_image()
+
+    mask, skipped, supported = dicom._generate_rtstruct_mask_array([_square_contour(z=10.0)], image)
+
+    assert supported == 1
+    assert skipped == 1
+    assert not mask.any()
+
+
+@pytest.mark.unit
+def test_rtstruct_xor_contour_is_applied_once_per_contour():
+    image = _make_sitk_image()
+
+    mask, skipped, supported = dicom._generate_rtstruct_mask_array(
+        [_square_contour(contour_type="CLOSED_PLANAR_XOR")],
+        image,
+    )
+
+    assert supported == 1
+    assert skipped == 0
+    assert mask[1].any()
+
+
+@pytest.mark.unit
+def test_extract_dicom_mask_warns_when_some_contours_are_outside_target_fov(tmp_path):
+    frame_uid = "1.2.826.0.1.3680043.8.498.2"
+    rtstruct_path = tmp_path / "rtstruct.dcm"
+    _write_rtstruct(rtstruct_path, "GTV", frame_uid, [_square_contour(), _square_contour(z=10.0)])
+    image = _make_sitk_image(frame_uid=frame_uid)
+
+    with pytest.warns(DataStructureWarning, match="Skipped 1 RTSTRUCT contour"):
+        mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
+
+    assert mask.array is not None
+    assert mask.array.any()
+
+
+@pytest.mark.unit
+def test_extract_dicom_mask_returns_empty_image_when_roi_has_no_target_fov_overlap(tmp_path):
+    frame_uid = "1.2.826.0.1.3680043.8.498.3"
+    rtstruct_path = tmp_path / "rtstruct.dcm"
+    _write_rtstruct(rtstruct_path, "GTV", frame_uid, [_square_contour(z=10.0)])
+    image = _make_sitk_image(frame_uid=frame_uid)
+
+    with pytest.warns(DataStructureWarning, match="has no overlap"):
+        mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
+
+    assert mask.array is None
+
+
+@pytest.mark.unit
+def test_rtstruct_matching_frame_of_reference_uid_passes():
+    image = _make_sitk_image(frame_uid="1.2.3")
+
+    dicom._validate_rtstruct_frame_of_reference({"referenced_frame": "1.2.3"}, image, "GTV")
+
+
+@pytest.mark.unit
+def test_rtstruct_mismatched_frame_of_reference_uid_raises():
+    image = _make_sitk_image(frame_uid="1.2.3")
+
+    with pytest.raises(DataStructureError, match="FrameOfReferenceUID"):
+        dicom._validate_rtstruct_frame_of_reference({"referenced_frame": "4.5.6"}, image, "GTV")
+
+
+@pytest.mark.unit
+def test_rtstruct_missing_frame_of_reference_uid_warns_and_continues():
+    image = _make_sitk_image(frame_uid=None)
+
+    with pytest.warns(DataStructureWarning, match="could not be verified"):
+        dicom._validate_rtstruct_frame_of_reference({"referenced_frame": "1.2.3"}, image, "GTV")
+
+
+@pytest.mark.unit
+def test_process_dicom_series_preserves_frame_of_reference_uid(monkeypatch):
+    frame_uid = "1.2.826.0.1.3680043.8.498.4"
+
+    class FakeReader:
+        def SetFileNames(self, file_names):
+            self.file_names = file_names
+
+        def Execute(self):
+            return sitk.GetImageFromArray(np.full((2, 2, 2), -1000, dtype=np.int16))
+
+    def make_ds(z):
+        ds = Dataset()
+        ds.Modality = "CT"
+        ds.PixelSpacing = [1.0, 1.0]
+        ds.ImageOrientationPatient = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+        ds.ImagePositionPatient = [0.0, 0.0, z]
+        ds.FrameOfReferenceUID = frame_uid
+        return ds
+
+    monkeypatch.setattr(dicom.sitk, "ImageSeriesReader", FakeReader)
+    dicom_files = [
+        {"file_path": "slice-1.dcm", "ds": make_ds(0.0)},
+        {"file_path": "slice-2.dcm", "ds": make_ds(2.0)},
+    ]
+
+    image = dicom.process_dicom_series(dicom_files)
+
+    assert image.GetMetaData(dicom.FRAME_OF_REFERENCE_UID_KEY) == frame_uid
+    assert image.GetMetaData(dicom.FRAME_OF_REFERENCE_UID_NAME) == frame_uid

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pydicom
 import pytest
@@ -12,15 +10,12 @@ import zrad.io.dicom as dicom
 from zrad.exceptions import DataStructureWarning
 
 
-def _make_sitk_image(size=(5, 5, 3), frame_uid="1.2.826.0.1.3680043.8.498.1"):
+def _make_sitk_image(size=(5, 5, 3)):
     width, height, depth = size
     image = sitk.GetImageFromArray(np.zeros((depth, height, width), dtype=np.int16))
     image.SetOrigin((0.0, 0.0, 0.0))
     image.SetSpacing((1.0, 1.0, 1.0))
     image.SetDirection((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
-    if frame_uid is not None:
-        image.SetMetaData(dicom.FRAME_OF_REFERENCE_UID_KEY, frame_uid)
-        image.SetMetaData(dicom.FRAME_OF_REFERENCE_UID_NAME, frame_uid)
     return image
 
 
@@ -44,7 +39,7 @@ def _square_contour(z=1.0, contour_type="CLOSED_PLANAR"):
     )
 
 
-def _write_rtstruct(path, roi_name, frame_uid, contours):
+def _write_rtstruct(path, roi_name, contours):
     file_meta = FileMetaDataset()
     file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
     file_meta.MediaStorageSOPClassUID = generate_uid()
@@ -61,8 +56,6 @@ def _write_rtstruct(path, roi_name, frame_uid, contours):
     structure = Dataset()
     structure.ROINumber = 1
     structure.ROIName = roi_name
-    if frame_uid is not None:
-        structure.ReferencedFrameOfReferenceUID = frame_uid
     ds.StructureSetROISequence = Sequence([structure])
 
     roi_contour = Dataset()
@@ -141,10 +134,9 @@ def test_rtstruct_xor_contour_is_applied_once_per_contour():
 
 @pytest.mark.unit
 def test_extract_dicom_mask_warns_when_some_contours_are_outside_target_fov(tmp_path):
-    frame_uid = "1.2.826.0.1.3680043.8.498.2"
     rtstruct_path = tmp_path / "rtstruct.dcm"
-    _write_rtstruct(rtstruct_path, "GTV", frame_uid, [_square_contour(), _square_contour(z=10.0)])
-    image = _make_sitk_image(frame_uid=frame_uid)
+    _write_rtstruct(rtstruct_path, "GTV", [_square_contour(), _square_contour(z=10.0)])
+    image = _make_sitk_image()
 
     with pytest.warns(DataStructureWarning, match="Skipped 1 RTSTRUCT contour"):
         mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
@@ -155,58 +147,12 @@ def test_extract_dicom_mask_warns_when_some_contours_are_outside_target_fov(tmp_
 
 @pytest.mark.unit
 def test_extract_dicom_mask_returns_empty_image_when_roi_has_no_target_fov_overlap(tmp_path):
-    frame_uid = "1.2.826.0.1.3680043.8.498.3"
     rtstruct_path = tmp_path / "rtstruct.dcm"
-    _write_rtstruct(rtstruct_path, "GTV", frame_uid, [_square_contour(z=10.0)])
-    image = _make_sitk_image(frame_uid=frame_uid)
+    _write_rtstruct(rtstruct_path, "GTV", [_square_contour(z=10.0)])
+    image = _make_sitk_image()
 
     with pytest.warns(DataStructureWarning, match="has no overlap"):
         mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
 
     assert mask.array is None
 
-
-@pytest.mark.unit
-def test_extract_dicom_mask_does_not_validate_frame_of_reference_uid(tmp_path):
-    rtstruct_path = tmp_path / "rtstruct.dcm"
-    _write_rtstruct(rtstruct_path, "GTV", "1.2.826.0.1.3680043.8.498.5", [_square_contour()])
-    image = _make_sitk_image(frame_uid="1.2.826.0.1.3680043.8.498.6")
-
-    with warnings.catch_warnings(record=True) as caught_warnings:
-        mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
-
-    assert mask.array is not None
-    assert mask.array.any()
-    assert not any(issubclass(warning.category, DataStructureWarning) for warning in caught_warnings)
-
-
-@pytest.mark.unit
-def test_process_dicom_series_preserves_frame_of_reference_uid(monkeypatch):
-    frame_uid = "1.2.826.0.1.3680043.8.498.4"
-
-    class FakeReader:
-        def SetFileNames(self, file_names):
-            self.file_names = file_names
-
-        def Execute(self):
-            return sitk.GetImageFromArray(np.full((2, 2, 2), -1000, dtype=np.int16))
-
-    def make_ds(z):
-        ds = Dataset()
-        ds.Modality = "CT"
-        ds.PixelSpacing = [1.0, 1.0]
-        ds.ImageOrientationPatient = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0]
-        ds.ImagePositionPatient = [0.0, 0.0, z]
-        ds.FrameOfReferenceUID = frame_uid
-        return ds
-
-    monkeypatch.setattr(dicom.sitk, "ImageSeriesReader", FakeReader)
-    dicom_files = [
-        {"file_path": "slice-1.dcm", "ds": make_ds(0.0)},
-        {"file_path": "slice-2.dcm", "ds": make_ds(2.0)},
-    ]
-
-    image = dicom.process_dicom_series(dicom_files)
-
-    assert image.GetMetaData(dicom.FRAME_OF_REFERENCE_UID_KEY) == frame_uid
-    assert image.GetMetaData(dicom.FRAME_OF_REFERENCE_UID_NAME) == frame_uid

--- a/zrad/__init__.py
+++ b/zrad/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "26.5.1.dev0"
+__version__ = "26.6.0.dev0"

--- a/zrad/io/dicom.py
+++ b/zrad/io/dicom.py
@@ -264,40 +264,6 @@ def process_dicom_series(dicom_files):
     return image
 
 
-def _metadata_value(sitk_image, keys):
-    for key in keys:
-        if sitk_image.HasMetaDataKey(key):
-            value = sitk_image.GetMetaData(key).strip()
-            if value:
-                return value
-    return None
-
-
-def _reference_frame_uid(sitk_image):
-    return _metadata_value(sitk_image, [FRAME_OF_REFERENCE_UID_KEY, FRAME_OF_REFERENCE_UID_NAME])
-
-
-def _validate_rtstruct_frame_of_reference(rt_struct, sitk_image, roi_name):
-    rtstruct_frame_uid = rt_struct.get("referenced_frame")
-    if rtstruct_frame_uid:
-        rtstruct_frame_uid = str(rtstruct_frame_uid).strip()
-    image_frame_uid = _reference_frame_uid(sitk_image)
-
-    if rtstruct_frame_uid and image_frame_uid:
-        if rtstruct_frame_uid != image_frame_uid:
-            raise DataStructureError(
-                f"RTSTRUCT ROI '{roi_name}' references FrameOfReferenceUID {rtstruct_frame_uid}, "
-                f"but the image references {image_frame_uid}."
-            )
-        return
-
-    warnings.warn(
-        f"FrameOfReferenceUID could not be verified for RTSTRUCT ROI '{roi_name}'. "
-        "Mask generation will proceed using physical coordinates.",
-        DataStructureWarning,
-    )
-
-
 def _normalized_contour_type(contour):
     return contour["type"].upper().replace("_", "").strip()
 
@@ -394,7 +360,6 @@ def extract_dicom_mask(rtstruct_path, roi_name, image):
 
     rt_struct = get_contour_data(rtstruct_path, roi_name)
     if rt_struct and "sequence" in rt_struct:
-        _validate_rtstruct_frame_of_reference(rt_struct, image, roi_name)
         mask, skipped_outside_fov, _supported_contours = _generate_rtstruct_mask_array(rt_struct["sequence"], image)
         if skipped_outside_fov > 0 and np.any(mask):
             warnings.warn(

--- a/zrad/io/dicom.py
+++ b/zrad/io/dicom.py
@@ -10,6 +10,9 @@ from skimage import draw
 from ..exceptions import DataStructureError, DataStructureWarning
 from .pet_suv import apply_suv_correction, validate_pet_dicom_tags
 
+FRAME_OF_REFERENCE_UID_KEY = "0020|0052"
+FRAME_OF_REFERENCE_UID_NAME = "FrameOfReferenceUID"
+
 
 def read_dicom_image(dicom_dir, modality):
     """Read a DICOM image series as a SimpleITK image."""
@@ -243,6 +246,17 @@ def process_dicom_series(dicom_files):
 
     image.SetSpacing((float(pixel_spacing[0]), float(pixel_spacing[1]), float(slice_thickness)))
     image.SetDirection(direction)
+    frame_of_reference_uid = next(
+        (
+            getattr(dicom_file["ds"], "FrameOfReferenceUID", None)
+            for dicom_file in dicom_files
+            if getattr(dicom_file["ds"], "FrameOfReferenceUID", None)
+        ),
+        None,
+    )
+    if frame_of_reference_uid:
+        image.SetMetaData(FRAME_OF_REFERENCE_UID_KEY, str(frame_of_reference_uid))
+        image.SetMetaData(FRAME_OF_REFERENCE_UID_NAME, str(frame_of_reference_uid))
     if dicom_files[0]["ds"].Modality == "CT" and np.min(sitk.GetArrayFromImage(image)) >= 0:
         error_msg = f'Non-negative CT intensity. SITK failed to convert CT into HU for {dicom_files[0]["file_path"]}. The patient is excluded from analysis'
         raise DataStructureError(error_msg)
@@ -250,36 +264,89 @@ def process_dicom_series(dicom_files):
     return image
 
 
-def extract_dicom_mask(rtstruct_path, roi_name, image):
-    def generate_mask_array(contours, sitk_image):
-        width, height, depth = sitk_image.GetSize()
-        mask_array = np.zeros((depth, height, width), dtype=np.uint8)
+def _metadata_value(sitk_image, keys):
+    for key in keys:
+        if sitk_image.HasMetaDataKey(key):
+            value = sitk_image.GetMetaData(key).strip()
+            if value:
+                return value
+    return None
 
-        for contour in contours:
-            contour_type = contour["type"].upper().replace("_", "").strip()
-            if contour_type not in ["CLOSEDPLANAR", "INTERPOLATEDPLANAR", "CLOSEDPLANARXOR"]:
-                continue
 
-            points = contour["points"]
-            num_points = len(points["x"])
-            transformed_points = np.array(
-                [
-                    sitk_image.TransformPhysicalPointToContinuousIndex((points["x"][i], points["y"][i], points["z"][i]))
-                    for i in range(num_points)
-                ]
+def _reference_frame_uid(sitk_image):
+    return _metadata_value(sitk_image, [FRAME_OF_REFERENCE_UID_KEY, FRAME_OF_REFERENCE_UID_NAME])
+
+
+def _validate_rtstruct_frame_of_reference(rt_struct, sitk_image, roi_name):
+    rtstruct_frame_uid = rt_struct.get("referenced_frame")
+    if rtstruct_frame_uid:
+        rtstruct_frame_uid = str(rtstruct_frame_uid).strip()
+    image_frame_uid = _reference_frame_uid(sitk_image)
+
+    if rtstruct_frame_uid and image_frame_uid:
+        if rtstruct_frame_uid != image_frame_uid:
+            raise DataStructureError(
+                f"RTSTRUCT ROI '{roi_name}' references FrameOfReferenceUID {rtstruct_frame_uid}, "
+                f"but the image references {image_frame_uid}."
             )
+        return
 
-            z_indices = np.rint(transformed_points[:, 2]).astype(int)
-            polygon_coords = np.column_stack((transformed_points[:, 1], transformed_points[:, 0]))
-            mask_layer = draw.polygon2mask((height, width), polygon_coords)
+    warnings.warn(
+        f"FrameOfReferenceUID could not be verified for RTSTRUCT ROI '{roi_name}'. "
+        "Mask generation will proceed using physical coordinates.",
+        DataStructureWarning,
+    )
 
-            for z in z_indices:
-                if contour_type == "CLOSEDPLANARXOR":
-                    mask_array[z] = np.logical_xor(mask_array[z], mask_layer).astype(np.uint8)
-                else:
-                    mask_array[z] = np.logical_or(mask_array[z], mask_layer).astype(np.uint8)
 
-        return mask_array
+def _normalized_contour_type(contour):
+    return contour["type"].upper().replace("_", "").strip()
+
+
+def _generate_rtstruct_mask_array(contours, sitk_image):
+    width, height, depth = sitk_image.GetSize()
+    mask_array = np.zeros((depth, height, width), dtype=np.uint8)
+    skipped_outside_fov = 0
+    supported_contours = 0
+
+    for contour in contours:
+        contour_type = _normalized_contour_type(contour)
+        if contour_type not in ["CLOSEDPLANAR", "INTERPOLATEDPLANAR", "CLOSEDPLANARXOR"]:
+            continue
+
+        supported_contours += 1
+        points = contour["points"]
+        num_points = len(points["x"])
+        if num_points == 0:
+            skipped_outside_fov += 1
+            continue
+
+        transformed_points = np.array(
+            [
+                sitk_image.TransformPhysicalPointToContinuousIndex((points["x"][i], points["y"][i], points["z"][i]))
+                for i in range(num_points)
+            ]
+        )
+
+        z = int(np.rint(np.median(transformed_points[:, 2])))
+        if z < 0 or z >= depth:
+            skipped_outside_fov += 1
+            continue
+
+        polygon_coords = np.column_stack((transformed_points[:, 1], transformed_points[:, 0]))
+        mask_layer = draw.polygon2mask((height, width), polygon_coords)
+        if not mask_layer.any():
+            skipped_outside_fov += 1
+            continue
+
+        if contour_type == "CLOSEDPLANARXOR":
+            mask_array[z] = np.logical_xor(mask_array[z], mask_layer).astype(np.uint8)
+        else:
+            mask_array[z] = np.logical_or(mask_array[z], mask_layer).astype(np.uint8)
+
+    return mask_array, skipped_outside_fov, supported_contours
+
+
+def extract_dicom_mask(rtstruct_path, roi_name, image):
 
     def get_contour_data(file_path, selected_roi):
         def get_contour_coord(metadata, current_roi_sequence, skip_contours_bool=False):
@@ -289,7 +356,7 @@ def extract_dicom_mask(rtstruct_path, roi_name, image):
                 "referenced_frame": getattr(
                     metadata[current_roi_sequence.ReferencedROINumber],
                     "ReferencedFrameOfReferenceUID",
-                    "unknown",
+                    None,
                 ),
                 "display_color": getattr(current_roi_sequence, "ROIDisplayColor", []),
             }
@@ -327,7 +394,20 @@ def extract_dicom_mask(rtstruct_path, roi_name, image):
 
     rt_struct = get_contour_data(rtstruct_path, roi_name)
     if rt_struct and "sequence" in rt_struct:
-        mask = generate_mask_array(rt_struct["sequence"], image)
+        _validate_rtstruct_frame_of_reference(rt_struct, image, roi_name)
+        mask, skipped_outside_fov, _supported_contours = _generate_rtstruct_mask_array(rt_struct["sequence"], image)
+        if skipped_outside_fov > 0 and np.any(mask):
+            warnings.warn(
+                f"Skipped {skipped_outside_fov} RTSTRUCT contour(s) for ROI '{roi_name}' because they fall outside "
+                "the target image field of view.",
+                DataStructureWarning,
+            )
+        if not np.any(mask):
+            warnings.warn(
+                f"RTSTRUCT ROI '{roi_name}' has no overlap with the target image field of view. ROI skipped.",
+                DataStructureWarning,
+            )
+            return Image()
         return Image(
             array=mask,
             origin=image.GetOrigin(),

--- a/zrad/io/dicom.py
+++ b/zrad/io/dicom.py
@@ -10,9 +10,6 @@ from skimage import draw
 from ..exceptions import DataStructureError, DataStructureWarning
 from .pet_suv import apply_suv_correction, validate_pet_dicom_tags
 
-FRAME_OF_REFERENCE_UID_KEY = "0020|0052"
-FRAME_OF_REFERENCE_UID_NAME = "FrameOfReferenceUID"
-
 
 def read_dicom_image(dicom_dir, modality):
     """Read a DICOM image series as a SimpleITK image."""
@@ -246,17 +243,6 @@ def process_dicom_series(dicom_files):
 
     image.SetSpacing((float(pixel_spacing[0]), float(pixel_spacing[1]), float(slice_thickness)))
     image.SetDirection(direction)
-    frame_of_reference_uid = next(
-        (
-            getattr(dicom_file["ds"], "FrameOfReferenceUID", None)
-            for dicom_file in dicom_files
-            if getattr(dicom_file["ds"], "FrameOfReferenceUID", None)
-        ),
-        None,
-    )
-    if frame_of_reference_uid:
-        image.SetMetaData(FRAME_OF_REFERENCE_UID_KEY, str(frame_of_reference_uid))
-        image.SetMetaData(FRAME_OF_REFERENCE_UID_NAME, str(frame_of_reference_uid))
     if dicom_files[0]["ds"].Modality == "CT" and np.min(sitk.GetArrayFromImage(image)) >= 0:
         error_msg = f'Non-negative CT intensity. SITK failed to convert CT into HU for {dicom_files[0]["file_path"]}. The patient is excluded from analysis'
         raise DataStructureError(error_msg)
@@ -319,11 +305,6 @@ def extract_dicom_mask(rtstruct_path, roi_name, image):
             contour_info = {
                 "name": getattr(metadata[current_roi_sequence.ReferencedROINumber], "ROIName", "unknown"),
                 "roi_number": current_roi_sequence.ReferencedROINumber,
-                "referenced_frame": getattr(
-                    metadata[current_roi_sequence.ReferencedROINumber],
-                    "ReferencedFrameOfReferenceUID",
-                    None,
-                ),
                 "display_color": getattr(current_roi_sequence, "ROIDisplayColor", []),
             }
 

--- a/zrad/io/pet_suv.py
+++ b/zrad/io/pet_suv.py
@@ -518,4 +518,6 @@ def apply_suv_correction(dicom_files, suv_image):
     intensity_image.SetOrigin(suv_image.GetOrigin())
     intensity_image.SetSpacing(np.array(suv_image.GetSpacing()))
     intensity_image.SetDirection(np.array(suv_image.GetDirection()))
+    for key in suv_image.GetMetaDataKeys():
+        intensity_image.SetMetaData(key, suv_image.GetMetaData(key))
     return intensity_image

--- a/zrad/io/pet_suv.py
+++ b/zrad/io/pet_suv.py
@@ -518,6 +518,4 @@ def apply_suv_correction(dicom_files, suv_image):
     intensity_image.SetOrigin(suv_image.GetOrigin())
     intensity_image.SetSpacing(np.array(suv_image.GetSpacing()))
     intensity_image.SetDirection(np.array(suv_image.GetDirection()))
-    for key in suv_image.GetMetaDataKeys():
-        intensity_image.SetMetaData(key, suv_image.GetMetaData(key))
     return intensity_image


### PR DESCRIPTION
This PR makes DICOM RTSTRUCT-based mask generation crop-aware. Contours that fall outside the target image FOV are skipped instead of causing out-of-bounds indexing errors, while partially overlapping contours are rasterized onto the available image grid.

This is especially useful in multimodal or multi-acquisition settings when RTSTRUCTs defined on images with larger FOV are applied to images with a smaller FOV. 

It also adds focused tests for in-bounds contours, x/y clipping, z-out-of-bounds skipping, empty-overlap ROI handling, and XOR contour behavior.