### PR TITLE
ENH Add batch APIs for preprocessing, filtering, and radiomics

### DIFF
--- a/docs/reference/batch.rst
+++ b/docs/reference/batch.rst
@@ -1,6 +1,29 @@
 Batch
 =====
 
+``zrad.batch`` contains save-to-disk workflows for processing many case
+folders with one configuration. Use these classes when you want the same
+operation that the GUI performs over a cohort of patients.
+
+The batch API currently includes:
+
+* ``BatchPreprocessor`` for DICOM/NIfTI preprocessing and mask export.
+* ``BatchFilter`` for applying one image filter to every selected case.
+* ``BatchRadiomicsExtractor`` for writing one radiomics CSV from many cases.
+
+The lower-level ``zrad.preprocessing``, ``zrad.filtering``, and
+``zrad.radiomics`` modules remain the single-image or single-ROI APIs.
+
+All batch workflows return ``BatchResult``:
+
+.. code-block:: python
+
+   result = batch.run()
+
+   print(result.processed_count, result.skipped_count, result.failed_count)
+   for case in result.errors:
+       print(case.case_name, case.error)
+
 .. currentmodule:: zrad
 
 .. autosummary::

--- a/docs/reference/batch.rst
+++ b/docs/reference/batch.rst
@@ -10,4 +10,6 @@ Batch
    ~batch.filtering.FilteringCaseResult
    ~batch.preprocessing.BatchPreprocessor
    ~batch.preprocessing.PreprocessingCaseResult
+   ~batch.radiomics.BatchRadiomicsExtractor
+   ~batch.radiomics.RadiomicsCaseResult
    ~batch.results.BatchResult

--- a/docs/reference/batch.rst
+++ b/docs/reference/batch.rst
@@ -1,0 +1,13 @@
+Batch
+=====
+
+.. currentmodule:: zrad
+
+.. autosummary::
+   :toctree: generated
+
+   ~batch.filtering.BatchFilter
+   ~batch.filtering.FilteringCaseResult
+   ~batch.preprocessing.BatchPreprocessor
+   ~batch.preprocessing.PreprocessingCaseResult
+   ~batch.results.BatchResult

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,6 +9,7 @@ navigation.
    :maxdepth: 2
 
    preprocessing
+   batch
    filtering
    radiomics
    image

--- a/docs/user/api_quickstart.rst
+++ b/docs/user/api_quickstart.rst
@@ -148,6 +148,8 @@ DICOM example:
    ).run()
 
    print(result.processed_count, result.failed_count)
+   for case in result.errors:
+       print(case.case_name, case.error)
 
 NIfTI example:
 
@@ -169,8 +171,37 @@ NIfTI example:
    ).run()
 
 ``BatchPreprocessor`` is a save-to-disk batch API. It reports per-case status
-through ``BatchResult``. Batch filtering and batch radiomics extraction are
-planned follow-up concepts and are not part of the first batch API.
+through ``BatchResult``.
+
+Batch Filtering
+---------------
+
+Use ``zrad.batch.BatchFilter`` when you want to apply one configured image
+filter to every selected case folder and write the filtered images to disk.
+The lower-level ``zrad.filtering`` classes remain the recommended API for
+single-image filtering.
+
+.. code-block:: python
+
+   from zrad.batch import BatchFilter
+
+   result = BatchFilter(
+       input_directory="path/to/preprocessed_cases",
+       output_directory="path/to/filtered_cases",
+       input_data_type="nifti",
+       modality="CT",
+       nifti_image_name="image",
+       number_of_threads=8,
+       filter_type="Mean",
+       filter_dimension="3D",
+       padding_type="reflect",
+       mean_support=3,
+   ).run()
+
+   print(result.processed_count, result.failed_count)
+
+``BatchFilter`` is a save-to-disk batch API. Batch radiomics extraction is a
+planned follow-up concept and is not part of the first batch API.
 
 For parameter details, combine this quickstart with the dedicated user-guide
 pages and the API reference.

--- a/docs/user/api_quickstart.rst
+++ b/docs/user/api_quickstart.rst
@@ -119,5 +119,58 @@ that means your workflow needs to provide:
 For correct feature extraction, images and masks must refer to the same spatial
 frame and voxel grid.
 
+Batch Preprocessing
+-------------------
+
+Use ``zrad.batch.BatchPreprocessor`` when you want to run the preprocessing
+workflow over many case folders and write the processed images and masks to
+disk. The lower-level ``zrad.preprocessing`` classes remain the recommended API
+for single image/mask pairs and interactive experiments.
+
+DICOM example:
+
+.. code-block:: python
+
+   from zrad.batch import BatchPreprocessor
+
+   result = BatchPreprocessor(
+       input_directory="path/to/dicom_cases",
+       output_directory="path/to/preprocessed_cases",
+       input_data_type="dicom",
+       modality="CT",
+       number_of_threads=8,
+       structures=["CTV", "liver"],
+       resample_resolution=1.0,
+       resample_dimension="3D",
+       image_interpolation_method="linear",
+       mask_interpolation_method="linear",
+       mask_interpolation_threshold=0.5,
+   ).run()
+
+   print(result.processed_count, result.failed_count)
+
+NIfTI example:
+
+.. code-block:: python
+
+   from zrad.batch import BatchPreprocessor
+
+   result = BatchPreprocessor(
+       input_directory="path/to/nifti_cases",
+       output_directory="path/to/preprocessed_cases",
+       input_data_type="nifti",
+       modality="CT",
+       nifti_image_name="imageCT",
+       structures=["CTV", "liver"],
+       resample_resolution=1.0,
+       resample_dimension="2D",
+       image_interpolation_method="linear",
+       mask_interpolation_method="NN",
+   ).run()
+
+``BatchPreprocessor`` is a save-to-disk batch API. It reports per-case status
+through ``BatchResult``. Batch filtering and batch radiomics extraction are
+planned follow-up concepts and are not part of the first batch API.
+
 For parameter details, combine this quickstart with the dedicated user-guide
 pages and the API reference.

--- a/docs/user/api_quickstart.rst
+++ b/docs/user/api_quickstart.rst
@@ -200,8 +200,41 @@ single-image filtering.
 
    print(result.processed_count, result.failed_count)
 
-``BatchFilter`` is a save-to-disk batch API. Batch radiomics extraction is a
-planned follow-up concept and is not part of the first batch API.
+``BatchFilter`` is a save-to-disk batch API.
+
+Batch Radiomics
+---------------
+
+Use ``zrad.batch.BatchRadiomicsExtractor`` when you want to extract radiomics
+features for many case folders and write one ``radiomics.csv`` file. The
+lower-level ``zrad.radiomics.Radiomics`` class remains the recommended API for
+single prepared ROIs.
+
+.. code-block:: python
+
+   from zrad.batch import BatchRadiomicsExtractor
+
+   result = BatchRadiomicsExtractor(
+       input_directory="path/to/preprocessed_cases",
+       output_directory="path/to/radiomics_output",
+       input_data_type="nifti",
+       modality="CT",
+       nifti_image_name="image",
+       structures=["CTV", "liver"],
+       number_of_threads=8,
+       aggregation_dimension="3D",
+       aggregation_method="MERG",
+       discretization_method="Number of Bins",
+       number_of_bins=64,
+   ).run()
+
+   print(result.processed_count, result.skipped_count, result.failed_count)
+   for case in result.errors:
+       print(case.case_name, case.error)
+
+``BatchPreprocessor``, ``BatchFilter``, and ``BatchRadiomicsExtractor`` are
+save-to-disk batch APIs. They all report aggregate and per-case status through
+``BatchResult``.
 
 For parameter details, combine this quickstart with the dedicated user-guide
 pages and the API reference.

--- a/docs/user/api_quickstart.rst
+++ b/docs/user/api_quickstart.rst
@@ -119,6 +119,26 @@ that means your workflow needs to provide:
 For correct feature extraction, images and masks must refer to the same spatial
 frame and voxel grid.
 
+Batch APIs
+----------
+
+Use ``zrad.batch`` when you want to process a folder cohort and write results
+to disk. The lower-level modules remain the single-image or single-ROI APIs:
+
+* ``BatchPreprocessor`` writes preprocessed images and masks.
+* ``BatchFilter`` writes filtered images.
+* ``BatchRadiomicsExtractor`` writes one ``radiomics.csv`` file.
+
+All batch workflows return ``BatchResult``:
+
+.. code-block:: python
+
+   result = batch.run()
+
+   print(result.processed_count, result.skipped_count, result.failed_count)
+   for case in result.errors:
+       print(case.case_name, case.error)
+
 Batch Preprocessing
 -------------------
 

--- a/tests/test_batch_filtering.py
+++ b/tests/test_batch_filtering.py
@@ -1,0 +1,276 @@
+import numpy as np
+import pytest
+
+import zrad.batch as batch
+import zrad.batch.filtering as batch_filtering
+from zrad.batch import BatchFilter, BatchResult, FilteringCaseResult
+from zrad.exceptions import InvalidInputParametersError
+from zrad.gui.filt_tab import create_batch_filter_from_input_params
+from zrad.image import Image
+
+
+def _make_image(array=None):
+    if array is None:
+        array = np.ones((3, 3, 3), dtype=np.float64)
+    return Image(
+        array=np.asarray(array, dtype=np.float64),
+        origin=[0.0, 0.0, 0.0],
+        spacing=[1.0, 1.0, 1.0],
+        direction=[1, 0, 0, 0, 1, 0, 0, 0, 1],
+        shape=(array.shape[2], array.shape[1], array.shape[0]),
+    )
+
+
+def _write_case(input_dir, case_name, image_name='image'):
+    case_dir = input_dir / case_name
+    case_dir.mkdir(parents=True)
+    _make_image().save_as_nifti(case_dir / f'{image_name}.nii.gz')
+    return case_dir
+
+
+def _mean_filter(input_dir, output_dir, **kwargs):
+    params = {
+        'input_directory': input_dir,
+        'output_directory': output_dir,
+        'input_data_type': 'nifti',
+        'modality': 'CT',
+        'nifti_image_name': 'image',
+        'number_of_threads': 1,
+        'filter_type': 'Mean',
+        'filter_dimension': '3D',
+        'padding_type': 'reflect',
+        'mean_support': 3,
+    }
+    params.update(kwargs)
+    return BatchFilter(**params)
+
+
+@pytest.mark.unit
+def test_batch_public_api_exposes_filtering_classes():
+    assert BatchFilter is batch.BatchFilter
+    assert FilteringCaseResult is batch.FilteringCaseResult
+    assert BatchResult is batch.BatchResult
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({'input_data_type': 'unsupported'}, "input_data_type"),
+        ({'number_of_threads': 0}, "number_of_threads"),
+        ({'nifti_image_name': None}, "nifti_image_name"),
+        ({'mean_support': None}, "mean_support"),
+    ],
+)
+def test_batch_filter_validates_inputs(tmp_path, kwargs, message):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    batch_filter = _mean_filter(input_dir, output_dir, **kwargs)
+
+    with pytest.raises(InvalidInputParametersError, match=message):
+        batch_filter.validate()
+
+
+@pytest.mark.unit
+def test_batch_filter_selects_all_patient_folders(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    (input_dir / '.hidden').mkdir()
+    (input_dir / 'case_a').mkdir()
+    (input_dir / 'case_b').mkdir()
+
+    assert _mean_filter(input_dir, output_dir).plan() == ['case_a', 'case_b']
+
+
+@pytest.mark.unit
+def test_batch_filter_selects_explicit_patient_folders(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    batch_filter = _mean_filter(input_dir, output_dir, patient_folders=['case_b', 'case_a'])
+
+    assert batch_filter.plan() == ['case_b', 'case_a']
+
+
+@pytest.mark.unit
+def test_batch_filter_selects_numeric_folder_range(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    for folder in ['1', '2', '3', 'case_a']:
+        (input_dir / folder).mkdir()
+
+    batch_filter = _mean_filter(input_dir, output_dir, start_folder=2, stop_folder=3)
+
+    assert batch_filter.plan() == ['2', '3']
+
+
+@pytest.mark.unit
+def test_nifti_mean_filter_writes_expected_output(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    result = _mean_filter(input_dir, output_dir).run()
+
+    expected = output_dir / 'case_a' / 'Mean_3D_3support_reflect.nii.gz'
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.output_path == expected
+    assert expected.exists()
+
+
+@pytest.mark.unit
+def test_missing_nifti_image_is_recorded_as_skipped_case(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+
+    result = _mean_filter(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.error
+    assert result.skipped_count == 1
+
+
+@pytest.mark.unit
+def test_unexpected_filter_failure_is_recorded_as_failed_case(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    def fail_create_filter(_self):
+        raise RuntimeError("filter failed")
+
+    monkeypatch.setattr(BatchFilter, '_create_filter', fail_create_filter)
+
+    result = _mean_filter(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'failed'
+    assert case_result.error == "filter failed"
+    assert result.failed_count == 1
+
+
+@pytest.mark.unit
+def test_dicom_filter_uses_dicom_reader(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+
+    monkeypatch.setattr(batch_filtering.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+
+    result = BatchFilter(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        filter_type='Mean',
+        filter_dimension='3D',
+        padding_type='reflect',
+        mean_support=3,
+    ).run()
+
+    expected = output_dir / 'case_a' / 'Mean_3D_3support_reflect.nii.gz'
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.output_path == expected
+    assert expected.exists()
+
+
+@pytest.mark.unit
+def test_sequential_progress_callback_reports_total_case_count(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+    _write_case(input_dir, 'case_b')
+    progress_steps = []
+
+    _mean_filter(input_dir, output_dir).run(progress_callback=progress_steps.append)
+
+    assert sum(progress_steps) == 2
+
+
+@pytest.mark.unit
+def test_parallel_progress_callback_reports_total_case_count(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+    _write_case(input_dir, 'case_b')
+    progress_steps = []
+
+    _mean_filter(
+        input_dir,
+        output_dir,
+        number_of_threads=2,
+        parallel_backend='threads',
+    ).run(progress_callback=progress_steps.append)
+
+    assert sum(progress_steps) == 2
+
+
+def _gui_input_params(**kwargs):
+    params = {
+        'input_directory': '/input',
+        'output_directory': '/output',
+        'input_data_type': 'nifti',
+        'input_image_modality': 'CT',
+        'number_of_threads': 4,
+        'list_of_patient_folders': ['case_a'],
+        'start_folder': None,
+        'stop_folder': None,
+        'nifti_image_name': 'image',
+        'filter_type': 'Mean',
+        'filter_dimension': '3D',
+        'filter_padding_type': 'reflect',
+        'filter_mean_support': '3',
+        'filter_log_sigma': '2',
+        'filter_log_cutoff': '4',
+        'filter_laws_response_map': 'L5E5',
+        'filter_laws_rot_inv': 'Enable',
+        'filter_laws_distance': '5',
+        'filter_laws_pooling': 'average',
+        'filter_laws_energy_map': 'Disable',
+        'filter_wavelet_resp_map_2D': 'LL',
+        'filter_wavelet_resp_map_3D': 'LLL',
+        'filter_wavelet_type': 'haar',
+        'filter_wavelet_decomp_lvl': '1',
+        'filter_wavelet_rot_inv': 'Enable',
+        'filter_gabor_res_mm': '1',
+        'filter_gabor_sigma_mm': '2',
+        'filter_gabor_lambda_mm': '3',
+        'filter_gabor_gamma': '0.5',
+        'filter_gabor_theta': '0',
+        'filter_gabor_rotinv': 'Enable',
+        'filter_gabor_ortho': 'Disable',
+    }
+    params.update(kwargs)
+    return params
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "filter_type, expected",
+    [
+        ('Mean', {'mean_support': '3'}),
+        ('Laplacian of Gaussian', {'log_sigma': '2', 'log_cutoff': '4'}),
+        ('Laws Kernels', {'laws_response_map': 'L5E5', 'laws_rotation_invariance': 'Enable'}),
+        ('Gabor', {'gabor_res_mm': '1', 'gabor_rotation_invariance': 'Enable'}),
+        ('Wavelets', {'wavelet_type': 'haar', 'wavelet_response_map': 'LLL'}),
+    ],
+)
+def test_gui_mapping_creates_batch_filter_for_filter_families(filter_type, expected):
+    batch_filter = create_batch_filter_from_input_params(
+        _gui_input_params(filter_type=filter_type),
+        parallel_backend='threads',
+    )
+
+    assert batch_filter.filter_type == filter_type
+    assert batch_filter.parallel_backend == 'threads'
+    for key, value in expected.items():
+        assert getattr(batch_filter, key) == value

--- a/tests/test_batch_preprocessing.py
+++ b/tests/test_batch_preprocessing.py
@@ -501,3 +501,26 @@ def test_gui_mapping_uses_nifti_mask_names():
     assert preprocessor.input_data_type == 'nifti'
     assert preprocessor.structures == ['mask_a', 'mask_b']
     assert preprocessor.nifti_image_name == 'image'
+
+
+@pytest.mark.unit
+def test_gui_mapping_ignores_stale_all_structures_for_nifti(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    preprocessor = create_batch_preprocessor_from_input_params(
+        _gui_input_params(
+            input_directory=str(input_dir),
+            output_directory=str(output_dir),
+            input_data_type='nifti',
+            nifti_structures=['mask_a', 'mask_b'],
+            use_all_structures=True,
+            just_save_as_nifti=True,
+        ),
+        parallel_backend='processes',
+    )
+
+    assert preprocessor.use_all_structures is False
+    assert preprocessor.structures == ['mask_a', 'mask_b']
+    preprocessor.validate()

--- a/tests/test_batch_preprocessing.py
+++ b/tests/test_batch_preprocessing.py
@@ -1,0 +1,271 @@
+import numpy as np
+import pytest
+
+import zrad.batch as batch
+import zrad.batch.preprocessing as batch_preprocessing
+from zrad.batch import BatchPreprocessor, BatchResult, PreprocessingCaseResult
+from zrad.exceptions import InvalidInputParametersError
+from zrad.image import Image
+
+
+def _make_image(array=None, spacing=None):
+    if array is None:
+        array = np.ones((2, 2, 2), dtype=np.float64)
+    if spacing is None:
+        spacing = [1.0, 1.0, 1.0]
+    return Image(
+        array=np.asarray(array, dtype=np.float64),
+        origin=[0.0, 0.0, 0.0],
+        spacing=spacing,
+        direction=[1, 0, 0, 0, 1, 0, 0, 0, 1],
+        shape=(array.shape[2], array.shape[1], array.shape[0]),
+    )
+
+
+def _write_case(input_dir, case_name, image_name='image', masks=None):
+    case_dir = input_dir / case_name
+    case_dir.mkdir(parents=True)
+    _make_image().save_as_nifti(case_dir / f'{image_name}.nii.gz')
+    for mask_name in masks or []:
+        _make_image().save_as_nifti(case_dir / f'{mask_name}.nii.gz')
+    return case_dir
+
+
+def _nifti_preprocessor(input_dir, output_dir, **kwargs):
+    params = {
+        'input_directory': input_dir,
+        'output_directory': output_dir,
+        'input_data_type': 'nifti',
+        'modality': 'CT',
+        'nifti_image_name': 'image',
+        'number_of_threads': 1,
+        'structures': ['mask'],
+        'just_save_as_nifti': True,
+    }
+    params.update(kwargs)
+    return BatchPreprocessor(**params)
+
+
+@pytest.mark.unit
+def test_batch_public_api_exposes_preprocessing_classes():
+    assert set(batch.__all__) == {
+        'BatchPreprocessor',
+        'BatchResult',
+        'PreprocessingCaseResult',
+    }
+    assert BatchPreprocessor is batch.BatchPreprocessor
+    assert BatchResult is batch.BatchResult
+    assert PreprocessingCaseResult is batch.PreprocessingCaseResult
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({'input_data_type': 'unsupported'}, "input_data_type"),
+        ({'number_of_threads': 0}, "number_of_threads"),
+        ({'nifti_image_name': None}, "nifti_image_name"),
+        ({'use_all_structures': True}, "use_all_structures"),
+        ({'just_save_as_nifti': False, 'resample_resolution': None}, "resample_resolution"),
+    ],
+)
+def test_batch_preprocessor_validates_inputs(tmp_path, kwargs, message):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    preprocessor = _nifti_preprocessor(input_dir, output_dir, **kwargs)
+
+    with pytest.raises(InvalidInputParametersError, match=message):
+        preprocessor.validate()
+
+
+@pytest.mark.unit
+def test_batch_preprocessor_selects_all_patient_folders(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    (input_dir / '.hidden').mkdir()
+    (input_dir / 'case_a').mkdir()
+    (input_dir / 'case_b').mkdir()
+
+    assert _nifti_preprocessor(input_dir, output_dir).plan() == ['case_a', 'case_b']
+
+
+@pytest.mark.unit
+def test_batch_preprocessor_selects_explicit_patient_folders(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    preprocessor = _nifti_preprocessor(input_dir, output_dir, patient_folders=['case_b', 'case_a'])
+
+    assert preprocessor.plan() == ['case_b', 'case_a']
+
+
+@pytest.mark.unit
+def test_batch_preprocessor_selects_numeric_folder_range(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    for folder in ['1', '2', '3', 'case_a']:
+        (input_dir / folder).mkdir()
+
+    preprocessor = _nifti_preprocessor(input_dir, output_dir, start_folder=2, stop_folder=3)
+
+    assert preprocessor.plan() == ['2', '3']
+
+
+@pytest.mark.unit
+def test_nifti_convert_only_writes_image_and_masks(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+
+    result = _nifti_preprocessor(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert result.processed_count == 1
+    assert case_result.status == 'processed'
+    assert case_result.image_output_path == output_dir / 'case_a' / 'image.nii.gz'
+    assert case_result.mask_output_paths == {'mask': output_dir / 'case_a' / 'mask.nii.gz'}
+    assert (output_dir / 'case_a' / 'image.nii.gz').exists()
+    assert (output_dir / 'case_a' / 'mask.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_nifti_resampling_writes_outputs(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+
+    result = _nifti_preprocessor(
+        input_dir,
+        output_dir,
+        just_save_as_nifti=False,
+        resample_resolution=1.0,
+        resample_dimension='3D',
+        image_interpolation_method='linear',
+        mask_interpolation_method='NN',
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert (output_dir / 'case_a' / 'image.nii.gz').exists()
+    assert (output_dir / 'case_a' / 'mask.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_missing_nifti_mask_is_recorded_as_skipped_structure(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    result = _nifti_preprocessor(input_dir, output_dir, structures=['missing']).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.processed_structures == []
+    assert case_result.skipped_structures == ['missing']
+
+
+@pytest.mark.unit
+def test_nifti_mask_union_is_written_when_enabled(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask_a', 'mask_b'])
+
+    result = _nifti_preprocessor(
+        input_dir,
+        output_dir,
+        structures=['mask_a', 'mask_b'],
+        mask_union=True,
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.mask_union_output_path == output_dir / 'case_a' / 'mask_union.nii.gz'
+    assert (output_dir / 'case_a' / 'mask_union.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_dicom_preprocessor_uses_explicit_structures(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+
+    monkeypatch.setattr(batch_preprocessing.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(
+        batch_preprocessing.Image,
+        'from_dicom_mask',
+        staticmethod(lambda *args, **kwargs: _make_image()),
+    )
+    monkeypatch.setattr(
+        batch_preprocessing,
+        'get_dicom_files',
+        lambda *args, **kwargs: [{'file_path': str(input_dir / 'case_a' / 'rtstruct.dcm')}],
+    )
+
+    result = BatchPreprocessor(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        structures=['GTV'],
+        just_save_as_nifti=True,
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.processed_structures == ['GTV']
+    assert (output_dir / 'case_a' / 'GTV.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_dicom_preprocessor_resolves_all_structures(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+
+    monkeypatch.setattr(batch_preprocessing.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(
+        batch_preprocessing.Image,
+        'from_dicom_mask',
+        staticmethod(lambda *args, **kwargs: _make_image()),
+    )
+    monkeypatch.setattr(
+        batch_preprocessing,
+        'get_dicom_files',
+        lambda *args, **kwargs: [{'file_path': str(input_dir / 'case_a' / 'rtstruct.dcm')}],
+    )
+    monkeypatch.setattr(batch_preprocessing, 'get_all_structure_names', lambda _path: ['GTV', 'CTV'])
+
+    result = BatchPreprocessor(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        use_all_structures=True,
+        just_save_as_nifti=True,
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.processed_structures == ['GTV', 'CTV']
+
+
+@pytest.mark.unit
+def test_batch_continues_after_case_level_failure(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_good', masks=['mask'])
+    (input_dir / 'case_bad').mkdir()
+
+    result = _nifti_preprocessor(
+        input_dir,
+        output_dir,
+        patient_folders=['case_good', 'case_bad'],
+    ).run()
+
+    assert result.total_count == 2
+    assert result.processed_count == 1
+    assert result.skipped_count == 1
+    assert [case.case_name for case in result.errors] == ['case_bad']

--- a/tests/test_batch_preprocessing.py
+++ b/tests/test_batch_preprocessing.py
@@ -4,6 +4,7 @@ import pytest
 import zrad.batch as batch
 import zrad.batch.preprocessing as batch_preprocessing
 from zrad.batch import BatchPreprocessor, BatchResult, PreprocessingCaseResult
+from zrad.batch._utils import find_nifti_file
 from zrad.exceptions import InvalidInputParametersError
 from zrad.gui.prep_tab import create_batch_preprocessor_from_input_params
 from zrad.image import Image
@@ -46,6 +47,56 @@ def _nifti_preprocessor(input_dir, output_dir, **kwargs):
     }
     params.update(kwargs)
     return BatchPreprocessor(**params)
+
+
+@pytest.mark.unit
+def test_find_nifti_file_prefers_nii_gz_for_extensionless_stem(tmp_path):
+    case_dir = tmp_path / 'case_a'
+    case_dir.mkdir()
+    nii_path = case_dir / 'image.nii'
+    nii_gz_path = case_dir / 'image.nii.gz'
+    nii_path.touch()
+    nii_gz_path.touch()
+
+    assert find_nifti_file(case_dir, 'image') == nii_gz_path
+
+
+@pytest.mark.unit
+def test_find_nifti_file_returns_nii_for_extensionless_stem_when_nii_gz_is_missing(tmp_path):
+    case_dir = tmp_path / 'case_a'
+    case_dir.mkdir()
+    nii_path = case_dir / 'image.nii'
+    nii_path.touch()
+
+    assert find_nifti_file(case_dir, 'image') == nii_path
+
+
+@pytest.mark.unit
+def test_find_nifti_file_returns_explicit_nii_gz_path(tmp_path):
+    case_dir = tmp_path / 'case_a'
+    case_dir.mkdir()
+    nii_gz_path = case_dir / 'image.nii.gz'
+    nii_gz_path.touch()
+
+    assert find_nifti_file(case_dir, 'image.nii.gz') == nii_gz_path
+
+
+@pytest.mark.unit
+def test_find_nifti_file_returns_explicit_nii_path(tmp_path):
+    case_dir = tmp_path / 'case_a'
+    case_dir.mkdir()
+    nii_path = case_dir / 'image.nii'
+    nii_path.touch()
+
+    assert find_nifti_file(case_dir, 'image.nii') == nii_path
+
+
+@pytest.mark.unit
+def test_find_nifti_file_returns_none_for_missing_file(tmp_path):
+    case_dir = tmp_path / 'case_a'
+    case_dir.mkdir()
+
+    assert find_nifti_file(case_dir, 'image') is None
 
 
 @pytest.mark.unit
@@ -189,6 +240,30 @@ def test_nifti_convert_only_writes_image_and_masks(tmp_path):
     assert case_result.mask_output_paths == {'mask': output_dir / 'case_a' / 'mask.nii.gz'}
     assert (output_dir / 'case_a' / 'image.nii.gz').exists()
     assert (output_dir / 'case_a' / 'mask.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_nifti_convert_only_prefers_nii_gz_when_stem_matches_multiple_files(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    case_dir = input_dir / 'case_a'
+    case_dir.mkdir(parents=True)
+    (case_dir / 'image.nii').touch()
+    (case_dir / 'image.nii.gz').touch()
+
+    loaded_paths = []
+
+    def load_nifti(path):
+        loaded_paths.append(path)
+        return _make_image()
+
+    monkeypatch.setattr(batch_preprocessing.Image, 'from_nifti', staticmethod(load_nifti))
+
+    result = _nifti_preprocessor(input_dir, output_dir, structures=None).run()
+
+    assert result.processed_count == 1
+    assert loaded_paths == [case_dir / 'image.nii.gz']
+    assert (output_dir / 'case_a' / 'image.nii.gz').exists()
 
 
 @pytest.mark.unit

--- a/tests/test_batch_preprocessing.py
+++ b/tests/test_batch_preprocessing.py
@@ -53,9 +53,11 @@ def test_batch_public_api_exposes_preprocessing_classes():
     assert set(batch.__all__) == {
         'BatchFilter',
         'BatchPreprocessor',
+        'BatchRadiomicsExtractor',
         'BatchResult',
         'FilteringCaseResult',
         'PreprocessingCaseResult',
+        'RadiomicsCaseResult',
     }
     assert BatchPreprocessor is batch.BatchPreprocessor
     assert BatchResult is batch.BatchResult

--- a/tests/test_batch_preprocessing.py
+++ b/tests/test_batch_preprocessing.py
@@ -5,6 +5,7 @@ import zrad.batch as batch
 import zrad.batch.preprocessing as batch_preprocessing
 from zrad.batch import BatchPreprocessor, BatchResult, PreprocessingCaseResult
 from zrad.exceptions import InvalidInputParametersError
+from zrad.gui.prep_tab import create_batch_preprocessor_from_input_params
 from zrad.image import Image
 
 
@@ -22,12 +23,13 @@ def _make_image(array=None, spacing=None):
     )
 
 
-def _write_case(input_dir, case_name, image_name='image', masks=None):
+def _write_case(input_dir, case_name, image_name='image', masks=None, mask_arrays=None):
     case_dir = input_dir / case_name
     case_dir.mkdir(parents=True)
     _make_image().save_as_nifti(case_dir / f'{image_name}.nii.gz')
     for mask_name in masks or []:
-        _make_image().save_as_nifti(case_dir / f'{mask_name}.nii.gz')
+        array = (mask_arrays or {}).get(mask_name)
+        _make_image(array=array).save_as_nifti(case_dir / f'{mask_name}.nii.gz')
     return case_dir
 
 
@@ -49,8 +51,10 @@ def _nifti_preprocessor(input_dir, output_dir, **kwargs):
 @pytest.mark.unit
 def test_batch_public_api_exposes_preprocessing_classes():
     assert set(batch.__all__) == {
+        'BatchFilter',
         'BatchPreprocessor',
         'BatchResult',
+        'FilteringCaseResult',
         'PreprocessingCaseResult',
     }
     assert BatchPreprocessor is batch.BatchPreprocessor
@@ -78,6 +82,38 @@ def test_batch_preprocessor_validates_inputs(tmp_path, kwargs, message):
 
     with pytest.raises(InvalidInputParametersError, match=message):
         preprocessor.validate()
+
+
+@pytest.mark.unit
+def test_batch_preprocessor_validate_normalizes_public_attributes(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    preprocessor = BatchPreprocessor(
+        input_directory=str(input_dir),
+        output_directory=str(output_dir),
+        input_data_type=' NIfTI ',
+        modality='ct',
+        number_of_threads='2',
+        patient_folders='case_a, case_b',
+        structures='mask_a, mask_b',
+        nifti_image_name=' image ',
+        just_save_as_nifti=True,
+        parallel_backend=' Threads ',
+    )
+
+    preprocessor.validate()
+
+    assert preprocessor.input_directory == input_dir
+    assert preprocessor.output_directory == output_dir
+    assert preprocessor.input_data_type == 'nifti'
+    assert preprocessor.modality == 'CT'
+    assert preprocessor.number_of_threads == 2
+    assert preprocessor.patient_folders == ['case_a', 'case_b']
+    assert preprocessor.structures == ['mask_a', 'mask_b']
+    assert preprocessor.nifti_image_name == 'image'
+    assert preprocessor.parallel_backend == 'threads'
 
 
 @pytest.mark.unit
@@ -117,6 +153,26 @@ def test_batch_preprocessor_selects_numeric_folder_range(tmp_path):
 
 
 @pytest.mark.unit
+def test_batch_preprocessor_plan_then_run_is_safe_after_normalization(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+
+    preprocessor = _nifti_preprocessor(
+        str(input_dir),
+        str(output_dir),
+        patient_folders='case_a',
+        structures='mask',
+    )
+
+    assert preprocessor.plan() == ['case_a']
+    result = preprocessor.run()
+
+    assert result.processed_count == 1
+    assert (output_dir / 'case_a' / 'image.nii.gz').exists()
+
+
+@pytest.mark.unit
 def test_nifti_convert_only_writes_image_and_masks(tmp_path):
     input_dir = tmp_path / 'input'
     output_dir = tmp_path / 'output'
@@ -131,6 +187,21 @@ def test_nifti_convert_only_writes_image_and_masks(tmp_path):
     assert case_result.mask_output_paths == {'mask': output_dir / 'case_a' / 'mask.nii.gz'}
     assert (output_dir / 'case_a' / 'image.nii.gz').exists()
     assert (output_dir / 'case_a' / 'mask.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_nifti_image_only_case_is_processed(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    result = _nifti_preprocessor(input_dir, output_dir, structures=None).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.processed_structures == []
+    assert case_result.skipped_structures == []
+    assert (output_dir / 'case_a' / 'image.nii.gz').exists()
 
 
 @pytest.mark.unit
@@ -156,6 +227,47 @@ def test_nifti_resampling_writes_outputs(tmp_path):
 
 
 @pytest.mark.unit
+def test_missing_nifti_image_is_recorded_as_skipped_case(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+
+    result = _nifti_preprocessor(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.error
+    assert result.skipped_count == 1
+
+
+@pytest.mark.unit
+def test_unexpected_processing_exception_is_recorded_as_failed_case(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    def fail_resampling(_self, _image):
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr(BatchPreprocessor, '_resample_image', fail_resampling)
+
+    result = _nifti_preprocessor(
+        input_dir,
+        output_dir,
+        just_save_as_nifti=False,
+        resample_resolution=1.0,
+        resample_dimension='3D',
+        image_interpolation_method='linear',
+        mask_interpolation_method='NN',
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'failed'
+    assert case_result.error == "unexpected failure"
+    assert result.failed_count == 1
+
+
+@pytest.mark.unit
 def test_missing_nifti_mask_is_recorded_as_skipped_structure(tmp_path):
     input_dir = tmp_path / 'input'
     output_dir = tmp_path / 'output'
@@ -170,10 +282,36 @@ def test_missing_nifti_mask_is_recorded_as_skipped_structure(tmp_path):
 
 
 @pytest.mark.unit
-def test_nifti_mask_union_is_written_when_enabled(tmp_path):
+def test_empty_mask_is_recorded_as_skipped_structure(monkeypatch, tmp_path):
     input_dir = tmp_path / 'input'
     output_dir = tmp_path / 'output'
-    _write_case(input_dir, 'case_a', masks=['mask_a', 'mask_b'])
+    _write_case(input_dir, 'case_a')
+
+    monkeypatch.setattr(BatchPreprocessor, '_load_mask', lambda *args, **kwargs: Image())
+
+    result = _nifti_preprocessor(input_dir, output_dir, structures=['empty']).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.processed_structures == []
+    assert case_result.skipped_structures == ['empty']
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "mask_arrays",
+    [
+        None,
+        {
+            'mask_a': np.array([[[0.0, 0.8], [1.2, 0.0]], [[0.0, 0.0], [0.0, 0.0]]]),
+            'mask_b': np.array([[[0.0, 0.0], [0.5, 1.0]], [[0.0, 1.0], [0.0, 0.0]]]),
+        },
+    ],
+)
+def test_nifti_mask_union_is_written_when_enabled(tmp_path, mask_arrays):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask_a', 'mask_b'], mask_arrays=mask_arrays)
 
     result = _nifti_preprocessor(
         input_dir,
@@ -185,6 +323,38 @@ def test_nifti_mask_union_is_written_when_enabled(tmp_path):
     case_result = result.case_results[0]
     assert case_result.mask_union_output_path == output_dir / 'case_a' / 'mask_union.nii.gz'
     assert (output_dir / 'case_a' / 'mask_union.nii.gz').exists()
+
+
+@pytest.mark.unit
+def test_sequential_progress_callback_reports_total_case_count(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+    _write_case(input_dir, 'case_b')
+    progress_steps = []
+
+    _nifti_preprocessor(input_dir, output_dir, structures=None).run(progress_callback=progress_steps.append)
+
+    assert sum(progress_steps) == 2
+
+
+@pytest.mark.unit
+def test_parallel_progress_callback_reports_total_case_count(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+    _write_case(input_dir, 'case_b')
+    progress_steps = []
+
+    _nifti_preprocessor(
+        input_dir,
+        output_dir,
+        structures=None,
+        number_of_threads=2,
+        parallel_backend='threads',
+    ).run(progress_callback=progress_steps.append)
+
+    assert sum(progress_steps) == 2
 
 
 @pytest.mark.unit
@@ -269,3 +439,63 @@ def test_batch_continues_after_case_level_failure(tmp_path):
     assert result.processed_count == 1
     assert result.skipped_count == 1
     assert [case.case_name for case in result.errors] == ['case_bad']
+
+
+def _gui_input_params(**kwargs):
+    params = {
+        'input_directory': '/input',
+        'output_directory': '/output',
+        'input_data_type': 'dicom',
+        'input_imaging_modality': 'CT',
+        'number_of_threads': 4,
+        'list_of_patient_folders': ['case_a'],
+        'start_folder': None,
+        'stop_folder': None,
+        'dicom_structures': ['GTV'],
+        'nifti_structures': ['mask'],
+        'nifti_image_name': 'image',
+        'just_save_as_nifti': False,
+        'resample_resolution': 1.0,
+        'resample_dimension': '3D',
+        'image_interpolation_method': 'linear',
+        'mask_interpolation_method': 'NN',
+        'mask_interpolation_threshold': 0.5,
+        'use_all_structures': False,
+        'mask_union': False,
+    }
+    params.update(kwargs)
+    return params
+
+
+@pytest.mark.unit
+def test_gui_mapping_uses_explicit_dicom_structures():
+    preprocessor = create_batch_preprocessor_from_input_params(_gui_input_params(), parallel_backend='processes')
+
+    assert preprocessor.input_data_type == 'dicom'
+    assert preprocessor.structures == ['GTV']
+    assert preprocessor.use_all_structures is False
+    assert preprocessor.parallel_backend == 'processes'
+
+
+@pytest.mark.unit
+def test_gui_mapping_uses_no_explicit_structures_when_all_dicom_structures_selected():
+    preprocessor = create_batch_preprocessor_from_input_params(
+        _gui_input_params(use_all_structures=True),
+        parallel_backend='threads',
+    )
+
+    assert preprocessor.structures is None
+    assert preprocessor.use_all_structures is True
+    assert preprocessor.parallel_backend == 'threads'
+
+
+@pytest.mark.unit
+def test_gui_mapping_uses_nifti_mask_names():
+    preprocessor = create_batch_preprocessor_from_input_params(
+        _gui_input_params(input_data_type='nifti', nifti_structures=['mask_a', 'mask_b']),
+        parallel_backend='processes',
+    )
+
+    assert preprocessor.input_data_type == 'nifti'
+    assert preprocessor.structures == ['mask_a', 'mask_b']
+    assert preprocessor.nifti_image_name == 'image'

--- a/tests/test_batch_radiomics.py
+++ b/tests/test_batch_radiomics.py
@@ -72,7 +72,13 @@ def test_batch_public_api_exposes_radiomics_classes():
         ({'use_all_structures': True}, "use_all_structures"),
         ({'discretization_method': 'Number of Bins', 'number_of_bins': None}, "number_of_bins"),
         ({'discretization_method': 'Bin Size', 'bin_size': None}, "bin_size"),
+        ({'discretization_method': 'Bin Size', 'bin_size': 25.0, 'intensity_range': None}, "intensity_range"),
+        (
+            {'discretization_method': 'Bin Size', 'bin_size': 25.0, 'intensity_range': [float('-inf'), 100.0]},
+            "intensity_range",
+        ),
         ({'aggregation_method': 'BAD'}, "aggregation_method"),
+        ({'slice_weighting': True, 'slice_median': True}, "slice_weighting"),
     ],
 )
 def test_batch_radiomics_validates_inputs(tmp_path, kwargs, message):
@@ -124,6 +130,28 @@ def test_batch_radiomics_validate_normalizes_public_attributes(tmp_path):
     assert extractor.number_of_bins == 8
     assert extractor.intensity_range == (0.0, 100.0)
     assert extractor.parallel_backend == 'threads'
+
+
+@pytest.mark.unit
+def test_batch_radiomics_plan_then_run_is_safe_after_normalization(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+
+    extractor = _extractor(
+        str(input_dir),
+        str(output_dir),
+        patient_folders='case_a',
+        structures='mask',
+        number_of_threads='1',
+    )
+
+    assert extractor.plan() == ['case_a']
+    result = extractor.run()
+
+    assert result.processed_count == 1
+    assert (output_dir / 'radiomics.csv').exists()
 
 
 @pytest.mark.unit
@@ -205,6 +233,20 @@ def test_filtered_nifti_image_is_loaded_when_provided(monkeypatch, tmp_path):
 
 
 @pytest.mark.unit
+def test_missing_filtered_nifti_image_is_recorded_as_skipped_case(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+
+    result = _extractor(input_dir, output_dir, nifti_filtered_image_name='filtered').run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.error
+    assert result.skipped_count == 1
+
+
+@pytest.mark.unit
 def test_missing_nifti_image_is_recorded_as_skipped_case(tmp_path):
     input_dir = tmp_path / 'input'
     output_dir = tmp_path / 'output'
@@ -229,6 +271,36 @@ def test_missing_nifti_mask_is_recorded_as_skipped_structure(tmp_path):
     case_result = result.case_results[0]
     assert case_result.status == 'skipped'
     assert case_result.skipped_structures == ['mask']
+    assert case_result.error == "No structures were successfully processed for radiomics extraction."
+
+
+@pytest.mark.unit
+def test_empty_nifti_mask_is_recorded_as_skipped_structure(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+    _make_image(np.zeros((3, 3, 3), dtype=np.float64)).save_as_nifti(input_dir / 'case_a' / 'mask.nii.gz')
+
+    result = _extractor(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.skipped_structures == ['mask']
+    assert case_result.error == "No structures were successfully processed for radiomics extraction."
+
+
+@pytest.mark.unit
+def test_empty_radiomics_csv_is_created_when_no_feature_rows_are_extracted(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    result = _extractor(input_dir, output_dir).run()
+
+    csv_path = output_dir / 'radiomics.csv'
+    assert result.skipped_count == 1
+    assert csv_path.exists()
+    assert csv_path.read_text() == ''
 
 
 @pytest.mark.unit
@@ -312,6 +384,58 @@ def test_dicom_radiomics_uses_all_structures(monkeypatch, tmp_path):
     ).run()
 
     assert result.case_results[0].processed_structures == ['GTV', 'CTV']
+
+
+@pytest.mark.unit
+def test_dicom_missing_rtstruct_is_recorded_as_skipped_case(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+    monkeypatch.setattr(batch_radiomics.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(batch_radiomics, 'get_dicom_files', lambda *args, **kwargs: [])
+
+    result = BatchRadiomicsExtractor(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        structures=['GTV'],
+        aggregation_dimension='3D',
+        aggregation_method='MERG',
+        discretization_method='Number of Bins',
+        number_of_bins=4,
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.skipped_structures == ['GTV']
+    assert case_result.error == "No structures were successfully processed for radiomics extraction."
+
+
+@pytest.mark.unit
+def test_dicom_all_structures_without_rtstruct_is_recorded_as_skipped_case(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+    monkeypatch.setattr(batch_radiomics.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(batch_radiomics, 'get_dicom_files', lambda *args, **kwargs: [])
+
+    result = BatchRadiomicsExtractor(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        use_all_structures=True,
+        aggregation_dimension='3D',
+        aggregation_method='MERG',
+        discretization_method='Number of Bins',
+        number_of_bins=4,
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.skipped_structures == []
+    assert case_result.error == "No structures were available for radiomics extraction."
 
 
 @pytest.mark.unit

--- a/tests/test_batch_radiomics.py
+++ b/tests/test_batch_radiomics.py
@@ -26,9 +26,7 @@ def _make_image(array=None):
 def _write_case(input_dir, case_name, image_name='image', masks=None, filtered_name=None):
     case_dir = input_dir / case_name
     case_dir.mkdir(parents=True)
-    _make_image(np.arange(1, 28, dtype=np.float64).reshape(3, 3, 3)).save_as_nifti(
-        case_dir / f'{image_name}.nii.gz'
-    )
+    _make_image(np.arange(1, 28, dtype=np.float64).reshape(3, 3, 3)).save_as_nifti(case_dir / f'{image_name}.nii.gz')
     if filtered_name:
         _make_image(np.full((3, 3, 3), 2.0)).save_as_nifti(case_dir / f'{filtered_name}.nii.gz')
     for mask_name in masks or []:

--- a/tests/test_batch_radiomics.py
+++ b/tests/test_batch_radiomics.py
@@ -302,6 +302,22 @@ def test_empty_radiomics_csv_is_created_when_no_feature_rows_are_extracted(tmp_p
 
 
 @pytest.mark.unit
+def test_empty_radiomics_csv_truncates_stale_content(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+    output_dir.mkdir()
+    csv_path = output_dir / 'radiomics.csv'
+    csv_path.write_text('pat_id,mask_id,old_feature\ncase_old,mask,1\n')
+
+    result = _extractor(input_dir, output_dir).run()
+
+    assert result.skipped_count == 1
+    assert csv_path.exists()
+    assert csv_path.read_text() == ''
+
+
+@pytest.mark.unit
 def test_per_structure_failure_skips_only_that_structure(monkeypatch, tmp_path):
     input_dir = tmp_path / 'input'
     output_dir = tmp_path / 'output'

--- a/tests/test_batch_radiomics.py
+++ b/tests/test_batch_radiomics.py
@@ -1,0 +1,435 @@
+import csv
+
+import numpy as np
+import pytest
+
+import zrad.batch as batch
+import zrad.batch.radiomics as batch_radiomics
+from zrad.batch import BatchRadiomicsExtractor, BatchResult, RadiomicsCaseResult
+from zrad.exceptions import DataStructureError, InvalidInputParametersError
+from zrad.gui.rad_tab import create_batch_radiomics_extractor_from_input_params
+from zrad.image import Image
+
+
+def _make_image(array=None):
+    if array is None:
+        array = np.ones((3, 3, 3), dtype=np.float64)
+    return Image(
+        array=np.asarray(array, dtype=np.float64),
+        origin=[0.0, 0.0, 0.0],
+        spacing=[1.0, 1.0, 1.0],
+        direction=[1, 0, 0, 0, 1, 0, 0, 0, 1],
+        shape=(array.shape[2], array.shape[1], array.shape[0]),
+    )
+
+
+def _write_case(input_dir, case_name, image_name='image', masks=None, filtered_name=None):
+    case_dir = input_dir / case_name
+    case_dir.mkdir(parents=True)
+    _make_image(np.arange(1, 28, dtype=np.float64).reshape(3, 3, 3)).save_as_nifti(
+        case_dir / f'{image_name}.nii.gz'
+    )
+    if filtered_name:
+        _make_image(np.full((3, 3, 3), 2.0)).save_as_nifti(case_dir / f'{filtered_name}.nii.gz')
+    for mask_name in masks or []:
+        _make_image(np.ones((3, 3, 3), dtype=np.float64)).save_as_nifti(case_dir / f'{mask_name}.nii.gz')
+    return case_dir
+
+
+def _extractor(input_dir, output_dir, **kwargs):
+    params = {
+        'input_directory': input_dir,
+        'output_directory': output_dir,
+        'input_data_type': 'nifti',
+        'modality': 'CT',
+        'nifti_image_name': 'image',
+        'number_of_threads': 1,
+        'structures': ['mask'],
+        'aggregation_dimension': '3D',
+        'aggregation_method': 'MERG',
+        'discretization_method': 'Number of Bins',
+        'number_of_bins': 4,
+    }
+    params.update(kwargs)
+    return BatchRadiomicsExtractor(**params)
+
+
+@pytest.mark.unit
+def test_batch_public_api_exposes_radiomics_classes():
+    assert BatchRadiomicsExtractor is batch.BatchRadiomicsExtractor
+    assert RadiomicsCaseResult is batch.RadiomicsCaseResult
+    assert BatchResult is batch.BatchResult
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({'input_data_type': 'unsupported'}, "input_data_type"),
+        ({'number_of_threads': 0}, "number_of_threads"),
+        ({'nifti_image_name': None}, "nifti_image_name"),
+        ({'structures': None}, "structures"),
+        ({'use_all_structures': True}, "use_all_structures"),
+        ({'discretization_method': 'Number of Bins', 'number_of_bins': None}, "number_of_bins"),
+        ({'discretization_method': 'Bin Size', 'bin_size': None}, "bin_size"),
+        ({'aggregation_method': 'BAD'}, "aggregation_method"),
+    ],
+)
+def test_batch_radiomics_validates_inputs(tmp_path, kwargs, message):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    extractor = _extractor(input_dir, output_dir, **kwargs)
+
+    with pytest.raises(InvalidInputParametersError, match=message):
+        extractor.validate()
+
+
+@pytest.mark.unit
+def test_batch_radiomics_validate_normalizes_public_attributes(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    extractor = BatchRadiomicsExtractor(
+        input_directory=str(input_dir),
+        output_directory=str(output_dir),
+        input_data_type=' NIfTI ',
+        modality='ct',
+        number_of_threads='2',
+        patient_folders='case_a, case_b',
+        structures='mask_a, mask_b',
+        nifti_image_name=' image ',
+        aggregation_dimension='3d',
+        aggregation_method='merg',
+        discretization_method='Number of Bins',
+        number_of_bins='8',
+        intensity_range='0, 100',
+        parallel_backend=' Threads ',
+    )
+
+    extractor.validate()
+
+    assert extractor.input_directory == input_dir
+    assert extractor.output_directory == output_dir
+    assert extractor.input_data_type == 'nifti'
+    assert extractor.modality == 'CT'
+    assert extractor.number_of_threads == 2
+    assert extractor.patient_folders == ['case_a', 'case_b']
+    assert extractor.structures == ['mask_a', 'mask_b']
+    assert extractor.nifti_image_name == 'image'
+    assert extractor.aggregation_dimension == '3D'
+    assert extractor.aggregation_method == 'MERG'
+    assert extractor.number_of_bins == 8
+    assert extractor.intensity_range == (0.0, 100.0)
+    assert extractor.parallel_backend == 'threads'
+
+
+@pytest.mark.unit
+def test_batch_radiomics_selects_all_patient_folders(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    (input_dir / '.hidden').mkdir()
+    (input_dir / 'case_a').mkdir()
+    (input_dir / 'case_b').mkdir()
+
+    assert _extractor(input_dir, output_dir).plan() == ['case_a', 'case_b']
+
+
+@pytest.mark.unit
+def test_batch_radiomics_selects_explicit_patient_folders(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    extractor = _extractor(input_dir, output_dir, patient_folders=['case_b', 'case_a'])
+
+    assert extractor.plan() == ['case_b', 'case_a']
+
+
+@pytest.mark.unit
+def test_batch_radiomics_selects_numeric_folder_range(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+    for folder in ['1', '2', '3', 'case_a']:
+        (input_dir / folder).mkdir()
+
+    extractor = _extractor(input_dir, output_dir, start_folder=2, stop_folder=3)
+
+    assert extractor.plan() == ['2', '3']
+
+
+@pytest.mark.unit
+def test_nifti_radiomics_writes_csv(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+    monkeypatch.setattr(
+        BatchRadiomicsExtractor,
+        '_extract_structure_features',
+        lambda *args, **kwargs: {'stat_mean': 1.5},
+    )
+
+    result = _extractor(input_dir, output_dir).run()
+
+    csv_path = output_dir / 'radiomics.csv'
+    assert result.workflow == 'radiomics'
+    assert result.processed_count == 1
+    assert result.case_results[0].processed_structures == ['mask']
+    with open(csv_path, newline='') as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    assert rows == [{'pat_id': 'case_a', 'mask_id': 'mask', 'stat_mean': '1.5'}]
+
+
+@pytest.mark.unit
+def test_filtered_nifti_image_is_loaded_when_provided(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+    loaded_names = []
+
+    def load_image(self, _case_dir, nifti_name=None):
+        loaded_names.append(nifti_name)
+        return _make_image()
+
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_load_image', load_image)
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_load_mask', lambda *args, **kwargs: _make_image())
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+
+    _extractor(input_dir, output_dir, nifti_filtered_image_name='filtered').run()
+
+    assert loaded_names == ['image', 'filtered']
+
+
+@pytest.mark.unit
+def test_missing_nifti_image_is_recorded_as_skipped_case(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+
+    result = _extractor(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.error
+    assert result.skipped_count == 1
+
+
+@pytest.mark.unit
+def test_missing_nifti_mask_is_recorded_as_skipped_structure(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a')
+
+    result = _extractor(input_dir, output_dir).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'skipped'
+    assert case_result.skipped_structures == ['mask']
+
+
+@pytest.mark.unit
+def test_per_structure_failure_skips_only_that_structure(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['good', 'bad'])
+
+    def load_mask(self, case_dir, structure_name, image, rtstruct_path):
+        if structure_name == 'bad':
+            raise DataStructureError("bad mask")
+        return _make_image()
+
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_load_mask', load_mask)
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+
+    result = _extractor(input_dir, output_dir, structures=['good', 'bad']).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.processed_structures == ['good']
+    assert case_result.skipped_structures == ['bad']
+
+
+@pytest.mark.unit
+def test_dicom_radiomics_uses_explicit_structures(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+    monkeypatch.setattr(batch_radiomics.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(batch_radiomics.Image, 'from_dicom_mask', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(
+        batch_radiomics,
+        'get_dicom_files',
+        lambda *args, **kwargs: [{'file_path': '/tmp/rtstruct.dcm'}],
+    )
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+
+    result = BatchRadiomicsExtractor(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        structures=['GTV'],
+        aggregation_dimension='3D',
+        aggregation_method='MERG',
+        discretization_method='Number of Bins',
+        number_of_bins=4,
+    ).run()
+
+    case_result = result.case_results[0]
+    assert case_result.status == 'processed'
+    assert case_result.processed_structures == ['GTV']
+
+
+@pytest.mark.unit
+def test_dicom_radiomics_uses_all_structures(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    (input_dir / 'case_a').mkdir(parents=True)
+    monkeypatch.setattr(batch_radiomics.Image, 'from_dicom', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(batch_radiomics.Image, 'from_dicom_mask', staticmethod(lambda *args, **kwargs: _make_image()))
+    monkeypatch.setattr(
+        batch_radiomics,
+        'get_dicom_files',
+        lambda *args, **kwargs: [{'file_path': '/tmp/rtstruct.dcm'}],
+    )
+    monkeypatch.setattr(batch_radiomics, 'get_all_structure_names', lambda _rtstruct_path: ['GTV', 'CTV'])
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+
+    result = BatchRadiomicsExtractor(
+        input_directory=input_dir,
+        output_directory=output_dir,
+        input_data_type='dicom',
+        modality='CT',
+        use_all_structures=True,
+        aggregation_dimension='3D',
+        aggregation_method='MERG',
+        discretization_method='Number of Bins',
+        number_of_bins=4,
+    ).run()
+
+    assert result.case_results[0].processed_structures == ['GTV', 'CTV']
+
+
+@pytest.mark.unit
+def test_batch_continues_after_failed_case(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+    _write_case(input_dir, 'case_b', masks=['mask'])
+
+    def fail_one_case(self, case_dir):
+        if case_dir.name == 'case_b':
+            raise RuntimeError("case failed")
+        return ['mask'], None
+
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_resolve_structures', fail_one_case)
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+
+    result = _extractor(input_dir, output_dir).run()
+
+    assert result.processed_count == 1
+    assert result.failed_count == 1
+    assert len(result.errors) == 1
+    assert result.errors[0].case_name == 'case_b'
+
+
+@pytest.mark.unit
+def test_sequential_progress_callback_reports_total_case_count(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+    _write_case(input_dir, 'case_b', masks=['mask'])
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+    progress_steps = []
+
+    _extractor(input_dir, output_dir).run(progress_callback=progress_steps.append)
+
+    assert sum(progress_steps) == 2
+
+
+@pytest.mark.unit
+def test_parallel_progress_callback_reports_total_case_count(monkeypatch, tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    _write_case(input_dir, 'case_a', masks=['mask'])
+    _write_case(input_dir, 'case_b', masks=['mask'])
+    monkeypatch.setattr(BatchRadiomicsExtractor, '_extract_structure_features', lambda *args, **kwargs: {'f': 1})
+    progress_steps = []
+
+    _extractor(
+        input_dir,
+        output_dir,
+        number_of_threads=2,
+        parallel_backend='threads',
+    ).run(progress_callback=progress_steps.append)
+
+    assert sum(progress_steps) == 2
+
+
+def _gui_input_params(**kwargs):
+    params = {
+        'input_directory': '/input',
+        'output_directory': '/output',
+        'input_data_type': 'nifti',
+        'input_imaging_modality': 'CT',
+        'number_of_threads': 4,
+        'list_of_patient_folders': ['case_a'],
+        'start_folder': None,
+        'stop_folder': None,
+        'nifti_structures': ['mask'],
+        'dicom_structures': ['GTV'],
+        'nifti_image_name': 'image',
+        'nifti_filtered_image_name': None,
+        'use_all_structures': False,
+        'aggregation_method': ('2D', 'AVER'),
+        'weighting': 'Weighted Mean',
+        'discretization': ('Number of Bins', 8, None),
+        'intensity_range': [0.0, 100.0],
+        'outlier_range': 3.0,
+    }
+    params.update(kwargs)
+    return params
+
+
+@pytest.mark.unit
+def test_gui_mapping_creates_nifti_batch_radiomics_extractor():
+    extractor = create_batch_radiomics_extractor_from_input_params(
+        _gui_input_params(),
+        parallel_backend='threads',
+    )
+
+    assert extractor.input_data_type == 'nifti'
+    assert extractor.structures == ['mask']
+    assert extractor.nifti_image_name == 'image'
+    assert extractor.slice_weighting is True
+    assert extractor.slice_median is False
+    assert extractor.parallel_backend == 'threads'
+
+
+@pytest.mark.unit
+def test_gui_mapping_creates_dicom_batch_radiomics_extractor_with_explicit_structures():
+    extractor = create_batch_radiomics_extractor_from_input_params(
+        _gui_input_params(input_data_type='dicom', weighting='Mean'),
+        parallel_backend='processes',
+    )
+
+    assert extractor.input_data_type == 'dicom'
+    assert extractor.structures == ['GTV']
+    assert extractor.use_all_structures is False
+    assert extractor.slice_weighting is False
+
+
+@pytest.mark.unit
+def test_gui_mapping_creates_dicom_batch_radiomics_extractor_with_all_structures():
+    extractor = create_batch_radiomics_extractor_from_input_params(
+        _gui_input_params(input_data_type='dicom', use_all_structures=True),
+        parallel_backend='threads',
+    )
+
+    assert extractor.input_data_type == 'dicom'
+    assert extractor.structures is None
+    assert extractor.use_all_structures is True

--- a/tests/test_batch_radiomics.py
+++ b/tests/test_batch_radiomics.py
@@ -533,6 +533,28 @@ def test_gui_mapping_creates_nifti_batch_radiomics_extractor():
 
 
 @pytest.mark.unit
+def test_gui_mapping_ignores_stale_all_structures_for_nifti(tmp_path):
+    input_dir = tmp_path / 'input'
+    output_dir = tmp_path / 'output'
+    input_dir.mkdir()
+
+    extractor = create_batch_radiomics_extractor_from_input_params(
+        _gui_input_params(
+            input_directory=str(input_dir),
+            output_directory=str(output_dir),
+            input_data_type='nifti',
+            nifti_structures=['mask_a', 'mask_b'],
+            use_all_structures=True,
+        ),
+        parallel_backend='threads',
+    )
+
+    assert extractor.use_all_structures is False
+    assert extractor.structures == ['mask_a', 'mask_b']
+    extractor.validate()
+
+
+@pytest.mark.unit
 def test_gui_mapping_creates_dicom_batch_radiomics_extractor_with_explicit_structures():
     extractor = create_batch_radiomics_extractor_from_input_params(
         _gui_input_params(input_data_type='dicom', weighting='Mean'),

--- a/zrad/__init__.py
+++ b/zrad/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "26.5.1.dev0"
+__version__ = "26.6.0.dev0"

--- a/zrad/batch/__init__.py
+++ b/zrad/batch/__init__.py
@@ -1,7 +1,11 @@
-from .preprocessing import BatchPreprocessor, BatchResult, PreprocessingCaseResult
+from .filtering import BatchFilter, FilteringCaseResult
+from .preprocessing import BatchPreprocessor, PreprocessingCaseResult
+from .results import BatchResult
 
 __all__ = [
+    'BatchFilter',
     'BatchPreprocessor',
     'BatchResult',
+    'FilteringCaseResult',
     'PreprocessingCaseResult',
 ]

--- a/zrad/batch/__init__.py
+++ b/zrad/batch/__init__.py
@@ -1,11 +1,14 @@
 from .filtering import BatchFilter, FilteringCaseResult
 from .preprocessing import BatchPreprocessor, PreprocessingCaseResult
+from .radiomics import BatchRadiomicsExtractor, RadiomicsCaseResult
 from .results import BatchResult
 
 __all__ = [
     'BatchFilter',
     'BatchPreprocessor',
+    'BatchRadiomicsExtractor',
     'BatchResult',
     'FilteringCaseResult',
     'PreprocessingCaseResult',
+    'RadiomicsCaseResult',
 ]

--- a/zrad/batch/__init__.py
+++ b/zrad/batch/__init__.py
@@ -1,0 +1,7 @@
+from .preprocessing import BatchPreprocessor, BatchResult, PreprocessingCaseResult
+
+__all__ = [
+    'BatchPreprocessor',
+    'BatchResult',
+    'PreprocessingCaseResult',
+]

--- a/zrad/batch/_utils.py
+++ b/zrad/batch/_utils.py
@@ -49,11 +49,7 @@ def resolve_patient_folders(input_directory: Path, patient_folders, start_folder
     if start_folder or stop_folder:
         raise InvalidInputParametersError("start_folder and stop_folder must be provided together.")
 
-    return [
-        path.name
-        for path in sorted(input_directory.iterdir())
-        if path.is_dir() and not path.name.startswith('.')
-    ]
+    return [path.name for path in sorted(input_directory.iterdir()) if path.is_dir() and not path.name.startswith('.')]
 
 
 def find_nifti_file(directory: Path, name: str | None) -> Path | None:

--- a/zrad/batch/_utils.py
+++ b/zrad/batch/_utils.py
@@ -1,0 +1,85 @@
+import contextlib
+from pathlib import Path
+from typing import Callable, Sequence
+
+import joblib
+
+from ..exceptions import InvalidInputParametersError
+
+
+def normalize_optional_text(value) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def require_text(value, message: str) -> str:
+    text = normalize_optional_text(value)
+    if not text:
+        raise InvalidInputParametersError(message)
+    return text
+
+
+def normalize_names(values: Sequence[str] | str | None) -> list[str] | None:
+    if values is None:
+        return None
+    if isinstance(values, str):
+        values = values.split(',')
+    normalized = [str(value).strip() for value in values if str(value).strip()]
+    return normalized or None
+
+
+def resolve_patient_folders(input_directory: Path, patient_folders, start_folder, stop_folder) -> list[str]:
+    if start_folder and stop_folder:
+        try:
+            start = int(start_folder)
+            stop = int(stop_folder)
+        except ValueError:
+            raise InvalidInputParametersError("start_folder and stop_folder must be integers.")
+        return [
+            path.name
+            for path in sorted(input_directory.iterdir())
+            if path.is_dir() and path.name.isdigit() and start <= int(path.name) <= stop
+        ]
+
+    if patient_folders:
+        return list(patient_folders)
+
+    if start_folder or stop_folder:
+        raise InvalidInputParametersError("start_folder and stop_folder must be provided together.")
+
+    return [
+        path.name
+        for path in sorted(input_directory.iterdir())
+        if path.is_dir() and not path.name.startswith('.')
+    ]
+
+
+def find_nifti_file(directory: Path, name: str | None) -> Path | None:
+    if name is None:
+        return None
+    base_path = directory / name
+    for candidate in [base_path.with_suffix(base_path.suffix + '.gz'), base_path.with_suffix('.nii'), base_path]:
+        if candidate.exists():
+            return candidate
+    nii_gz_path = directory / f'{name}.nii.gz'
+    if nii_gz_path.exists():
+        return nii_gz_path
+    return None
+
+
+@contextlib.contextmanager
+def joblib_progress(progress_callback: Callable[[int], None] | None = None):
+    class ProgressBatchCompletionCallback(joblib.parallel.BatchCompletionCallBack):
+        def __call__(self, *args, **kwargs):
+            if progress_callback:
+                progress_callback(self.batch_size)
+            return super().__call__(*args, **kwargs)
+
+    old_batch_callback = joblib.parallel.BatchCompletionCallBack
+    joblib.parallel.BatchCompletionCallBack = ProgressBatchCompletionCallback
+    try:
+        yield
+    finally:
+        joblib.parallel.BatchCompletionCallBack = old_batch_callback

--- a/zrad/batch/_utils.py
+++ b/zrad/batch/_utils.py
@@ -6,6 +6,8 @@ import joblib
 
 from ..exceptions import InvalidInputParametersError
 
+VALID_MODALITIES = ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']
+
 
 def normalize_optional_text(value) -> str | None:
     if value is None:
@@ -28,6 +30,36 @@ def normalize_names(values: Sequence[str] | str | None) -> list[str] | None:
         values = values.split(',')
     normalized = [str(value).strip() for value in values if str(value).strip()]
     return normalized or None
+
+
+def normalize_common_batch_options(batch) -> None:
+    batch.input_directory = Path(batch.input_directory)
+    batch.output_directory = Path(batch.output_directory)
+    batch.input_data_type = str(batch.input_data_type).strip().lower()
+    batch.modality = str(batch.modality).strip().upper()
+    batch.parallel_backend = str(batch.parallel_backend).strip().lower()
+    batch.patient_folders = normalize_names(batch.patient_folders)
+    batch.start_folder = normalize_optional_text(batch.start_folder)
+    batch.stop_folder = normalize_optional_text(batch.stop_folder)
+
+    if batch.input_data_type not in ['dicom', 'nifti']:
+        raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
+    if batch.modality not in VALID_MODALITIES:
+        raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
+    if not batch.input_directory.exists():
+        raise InvalidInputParametersError(f"Input directory '{batch.input_directory}' does not exist.")
+    if not batch.input_directory.is_dir():
+        raise InvalidInputParametersError(f"Input directory '{batch.input_directory}' is not a directory.")
+
+    try:
+        batch.number_of_threads = int(batch.number_of_threads)
+    except (TypeError, ValueError):
+        raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+    if batch.number_of_threads < 1:
+        raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+
+    if batch.parallel_backend not in ['processes', 'threads']:
+        raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
 
 
 def resolve_patient_folders(input_directory: Path, patient_folders, start_folder, stop_folder) -> list[str]:

--- a/zrad/batch/_utils.py
+++ b/zrad/batch/_utils.py
@@ -88,12 +88,14 @@ def find_nifti_file(directory: Path, name: str | None) -> Path | None:
     if name is None:
         return None
     base_path = directory / name
-    for candidate in [base_path.with_suffix(base_path.suffix + '.gz'), base_path.with_suffix('.nii'), base_path]:
+    if str(name).endswith(('.nii.gz', '.nii')):
+        candidates = [base_path]
+    else:
+        candidates = [directory / f'{name}.nii.gz', directory / f'{name}.nii', base_path]
+
+    for candidate in candidates:
         if candidate.exists():
             return candidate
-    nii_gz_path = directory / f'{name}.nii.gz'
-    if nii_gz_path.exists():
-        return nii_gz_path
     return None
 
 

--- a/zrad/batch/filtering.py
+++ b/zrad/batch/filtering.py
@@ -11,7 +11,7 @@ from ..image import Image
 from ._utils import (
     find_nifti_file,
     joblib_progress,
-    normalize_names,
+    normalize_common_batch_options,
     normalize_optional_text,
     require_text,
     resolve_patient_folders,
@@ -67,43 +67,19 @@ class BatchFilter:
     parallel_backend: str = 'processes'
 
     def validate(self) -> None:
-        self.input_directory = Path(self.input_directory)
-        self.output_directory = Path(self.output_directory)
-        self.input_data_type = str(self.input_data_type).strip().lower()
-        self.modality = str(self.modality).strip().upper()
-        self.parallel_backend = str(self.parallel_backend).strip().lower()
+        normalize_common_batch_options(self)
         self.filter_type = require_text(self.filter_type, "filter_type is required.")
         self.filter_dimension = require_text(self.filter_dimension, "filter_dimension is required.").upper()
         self.padding_type = require_text(self.padding_type, "padding_type is required.")
 
-        if self.input_data_type not in ['dicom', 'nifti']:
-            raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
-        if self.modality not in ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']:
-            raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
         if self.filter_dimension not in ['2D', '3D']:
             raise InvalidInputParametersError("filter_dimension must be '2D' or '3D'.")
-        if not self.input_directory.exists():
-            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
-        if not self.input_directory.is_dir():
-            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' is not a directory.")
-
-        try:
-            self.number_of_threads = int(self.number_of_threads)
-        except (TypeError, ValueError):
-            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
-        if self.number_of_threads < 1:
-            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
-        if self.parallel_backend not in ['processes', 'threads']:
-            raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
 
         if self.input_data_type == 'nifti':
             self.nifti_image_name = normalize_optional_text(self.nifti_image_name)
             if not self.nifti_image_name:
                 raise InvalidInputParametersError("nifti_image_name is required for NIfTI filtering.")
 
-        self.patient_folders = normalize_names(self.patient_folders)
-        self.start_folder = normalize_optional_text(self.start_folder)
-        self.stop_folder = normalize_optional_text(self.stop_folder)
         self._validate_filter_parameters()
 
     def plan(self) -> list[str]:

--- a/zrad/batch/filtering.py
+++ b/zrad/batch/filtering.py
@@ -23,6 +23,20 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class FilteringCaseResult:
+    """Per-case result returned by ``BatchFilter``.
+
+    Attributes
+    ----------
+    case_name : str
+        Name of the case folder.
+    status : {"processed", "skipped", "failed"}
+        Filtering status for the case.
+    output_path : pathlib.Path or None, optional
+        Path to the written filtered image when filtering succeeds.
+    error : str or None, optional
+        Case-level error message when image loading or filtering fails.
+    """
+
     case_name: str
     status: str
     output_path: Path | None = None
@@ -31,7 +45,59 @@ class FilteringCaseResult:
 
 @dataclass
 class BatchFilter:
-    """Run image filtering over many case folders and write NIfTI outputs."""
+    """Run one image filter over many case folders and write NIfTI outputs.
+
+    ``BatchFilter`` is the batch counterpart to the lower-level filtering
+    classes. It discovers case folders, loads one image per case, applies the
+    configured filter, and writes one filtered NIfTI image per processed case.
+    The API is save-to-disk only.
+
+    Parameters
+    ----------
+    input_directory : str or pathlib.Path
+        Directory containing one subfolder per case.
+    output_directory : str or pathlib.Path
+        Directory where filtered case folders are written.
+    input_data_type : {"dicom", "nifti"}
+        Input format. Values are normalized to lower-case during validation.
+    modality : {"CT", "MRI", "PET", "MG", "RTDOSE"}
+        Image modality used by the image reader.
+    filter_type : {"Mean", "Laplacian of Gaussian", "Laws Kernels", "Gabor", "Wavelets"}
+        Filter family to apply.
+    filter_dimension : {"2D", "3D"}
+        Apply the filter slice-wise in 2D or volumetrically in 3D.
+    padding_type : str
+        Boundary handling mode passed to the selected filter.
+    number_of_threads : int, optional
+        Number of cases to process in parallel. The default is ``1``.
+    patient_folders : sequence of str or str, optional
+        Explicit case folders to process. Comma-separated strings are accepted.
+    start_folder, stop_folder : str or int, optional
+        Inclusive numeric folder range. Both values must be provided together.
+    nifti_image_name : str, optional
+        Image file name or stem used for NIfTI input.
+    filter-specific settings : optional
+        Numeric and text settings required by the selected ``filter_type``:
+        ``mean_support``, ``log_sigma``, ``log_cutoff``,
+        ``laws_response_map``, ``laws_pooling``, ``laws_distance``,
+        ``wavelet_response_map``, ``wavelet_type``,
+        ``wavelet_decomposition_level``, ``gabor_res_mm``,
+        ``gabor_sigma_mm``, ``gabor_lambda_mm``, ``gabor_gamma``, and
+        ``gabor_theta``.
+    filter-specific enable settings : bool or str, optional
+        Enable/disable settings for Laws, Wavelets, and Gabor filters.
+        GUI-style ``"Enable"`` and ``"Disable"`` values are accepted.
+    parallel_backend : {"processes", "threads"}, optional
+        Joblib backend preference used when ``number_of_threads`` is greater
+        than one. The default is ``"processes"``.
+
+    Notes
+    -----
+    ``validate()`` normalizes public attributes in place. After validation,
+    directories are ``Path`` objects, ``input_data_type`` is lower-case,
+    modality is upper-case, and numeric filter settings are converted to
+    numeric Python values.
+    """
 
     input_directory: str | Path
     output_directory: str | Path
@@ -67,6 +133,15 @@ class BatchFilter:
     parallel_backend: str = 'processes'
 
     def validate(self) -> None:
+        """Validate and normalize filtering configuration.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If the input directory, data type, modality, folder selection,
+            threading, backend, filter type, or filter-specific settings are
+            invalid.
+        """
         normalize_common_batch_options(self)
         self.filter_type = require_text(self.filter_type, "filter_type is required.")
         self.filter_dimension = require_text(self.filter_dimension, "filter_dimension is required.").upper()
@@ -83,10 +158,45 @@ class BatchFilter:
         self._validate_filter_parameters()
 
     def plan(self) -> list[str]:
+        """Return the case folders selected for filtering.
+
+        Returns
+        -------
+        folders : list of str
+            Deterministically ordered case folder names selected by
+            ``patient_folders`` or the numeric ``start_folder`` /
+            ``stop_folder`` range. If neither option is set, all non-hidden
+            subfolders are returned.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If validation fails before folder selection.
+        """
         self.validate()
         return self._resolve_patient_folders()
 
     def run(self, progress_callback: Callable[[int], None] | None = None) -> BatchResult:
+        """Run filtering and write filtered NIfTI images.
+
+        Parameters
+        ----------
+        progress_callback : callable, optional
+            Function called as ``progress_callback(step_count)`` after cases
+            complete. ``step_count`` may be greater than one during parallel
+            execution.
+
+        Returns
+        -------
+        result : BatchResult
+            Aggregate result with one ``FilteringCaseResult`` per selected
+            case.
+
+        Notes
+        -----
+        Case-level failures are recorded in the returned result and do not stop
+        the batch.
+        """
         self.validate()
         self.output_directory.mkdir(parents=True, exist_ok=True)
         patient_folders = self._resolve_patient_folders()
@@ -106,6 +216,18 @@ class BatchFilter:
         return BatchResult(workflow='filtering', case_results=case_results)
 
     def get_output_filename(self) -> str:
+        """Return the GUI-compatible output file name for the configured filter.
+
+        Returns
+        -------
+        filename : str
+            File name ending in ``.nii.gz``.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If ``filter_type`` is not supported.
+        """
         values = self._filename_values()
         filter_formats = {
             'Mean': "{filter_type}_{filter_dimension}_{filter_mean_support}support_{filter_padding_type}",

--- a/zrad/batch/filtering.py
+++ b/zrad/batch/filtering.py
@@ -1,0 +1,352 @@
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+from joblib import Parallel, delayed
+
+from ..exceptions import DataStructureError, InvalidInputParametersError
+from ..filtering import create_filter
+from ..image import Image
+from ._utils import (
+    find_nifti_file,
+    joblib_progress,
+    normalize_names,
+    normalize_optional_text,
+    require_text,
+    resolve_patient_folders,
+)
+from .results import BatchResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FilteringCaseResult:
+    case_name: str
+    status: str
+    output_path: Path | None = None
+    error: str | None = None
+
+
+@dataclass
+class BatchFilter:
+    """Run image filtering over many case folders and write NIfTI outputs."""
+
+    input_directory: str | Path
+    output_directory: str | Path
+    input_data_type: str
+    modality: str
+    filter_type: str
+    filter_dimension: str
+    padding_type: str
+    number_of_threads: int = 1
+    patient_folders: Sequence[str] | None = None
+    start_folder: str | int | None = None
+    stop_folder: str | int | None = None
+    nifti_image_name: str | None = None
+    mean_support: int | str | None = None
+    log_sigma: float | str | None = None
+    log_cutoff: float | str | None = None
+    laws_response_map: str | None = None
+    laws_rotation_invariance: bool | str = False
+    laws_pooling: str | None = None
+    laws_energy_map: bool | str = False
+    laws_distance: int | str | None = None
+    wavelet_response_map: str | None = None
+    wavelet_type: str | None = None
+    wavelet_decomposition_level: int | str | None = None
+    wavelet_rotation_invariance: bool | str = False
+    gabor_res_mm: float | str | None = None
+    gabor_sigma_mm: float | str | None = None
+    gabor_lambda_mm: float | str | None = None
+    gabor_gamma: float | str | None = None
+    gabor_theta: float | str | None = None
+    gabor_rotation_invariance: bool | str = False
+    gabor_orthogonal_planes: bool | str = False
+    parallel_backend: str = 'processes'
+
+    def validate(self) -> None:
+        self.input_directory = Path(self.input_directory)
+        self.output_directory = Path(self.output_directory)
+        self.input_data_type = str(self.input_data_type).strip().lower()
+        self.modality = str(self.modality).strip().upper()
+        self.parallel_backend = str(self.parallel_backend).strip().lower()
+        self.filter_type = require_text(self.filter_type, "filter_type is required.")
+        self.filter_dimension = require_text(self.filter_dimension, "filter_dimension is required.").upper()
+        self.padding_type = require_text(self.padding_type, "padding_type is required.")
+
+        if self.input_data_type not in ['dicom', 'nifti']:
+            raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
+        if self.modality not in ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']:
+            raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
+        if self.filter_dimension not in ['2D', '3D']:
+            raise InvalidInputParametersError("filter_dimension must be '2D' or '3D'.")
+        if not self.input_directory.exists():
+            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
+        if not self.input_directory.is_dir():
+            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' is not a directory.")
+
+        try:
+            self.number_of_threads = int(self.number_of_threads)
+        except (TypeError, ValueError):
+            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+        if self.number_of_threads < 1:
+            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+        if self.parallel_backend not in ['processes', 'threads']:
+            raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
+
+        if self.input_data_type == 'nifti':
+            self.nifti_image_name = normalize_optional_text(self.nifti_image_name)
+            if not self.nifti_image_name:
+                raise InvalidInputParametersError("nifti_image_name is required for NIfTI filtering.")
+
+        self.patient_folders = normalize_names(self.patient_folders)
+        self.start_folder = normalize_optional_text(self.start_folder)
+        self.stop_folder = normalize_optional_text(self.stop_folder)
+        self._validate_filter_parameters()
+
+    def plan(self) -> list[str]:
+        self.validate()
+        return self._resolve_patient_folders()
+
+    def run(self, progress_callback: Callable[[int], None] | None = None) -> BatchResult:
+        self.validate()
+        self.output_directory.mkdir(parents=True, exist_ok=True)
+        patient_folders = self._resolve_patient_folders()
+
+        if self.number_of_threads == 1:
+            case_results = []
+            for patient_folder in patient_folders:
+                case_results.append(self._process_case(patient_folder))
+                if progress_callback:
+                    progress_callback(1)
+        else:
+            with joblib_progress(progress_callback):
+                case_results = Parallel(n_jobs=self.number_of_threads, prefer=self.parallel_backend)(
+                    delayed(self._process_case)(patient_folder) for patient_folder in patient_folders
+                )
+
+        return BatchResult(workflow='filtering', case_results=case_results)
+
+    def get_output_filename(self) -> str:
+        values = self._filename_values()
+        filter_formats = {
+            'Mean': "{filter_type}_{filter_dimension}_{filter_mean_support}support_{filter_padding_type}",
+            'Laplacian of Gaussian': "{filter_type}_{filter_dimension}_{filter_log_sigma}sigma_"
+            "{filter_log_cutoff}cutoff_{filter_padding_type}",
+            'Laws Kernels': "{filter_type}_{filter_dimension}_{filter_laws_response_map}_"
+            "{filter_laws_rot_inv}_{filter_laws_pooling}_"
+            "{filter_laws_energy_map}_{filter_laws_distance}_{filter_padding_type}",
+            'Gabor': "Gabor_{filter_dimension}_"
+            "{filter_gabor_res_mm}resmm_"
+            "{filter_gabor_sigma_mm}sigmm_"
+            "{filter_gabor_lambda_mm}lambmm_"
+            "g{filter_gabor_gamma}_"
+            "t{filter_gabor_theta}_"
+            "{filter_gabor_rotinv}_"
+            "{filter_gabor_ortho}_"
+            "{filter_padding_type}",
+        }
+
+        if self.filter_type == 'Wavelets':
+            filename = (
+                "{filter_wavelet_type}_{filter_dimension}_"
+                "{filter_wavelet_resp_map}_"
+                "{filter_wavelet_decomp_lvl}_"
+                "{filter_wavelet_rot_inv}_"
+                "{filter_padding_type}"
+            ).format(**values)
+        elif self.filter_type in filter_formats:
+            filename = filter_formats[self.filter_type].format(**values)
+        else:
+            raise InvalidInputParametersError(f"Unknown filter type: {self.filter_type}")
+        return f"{filename}.nii.gz"
+
+    def _resolve_patient_folders(self) -> list[str]:
+        return resolve_patient_folders(
+            self.input_directory,
+            self.patient_folders,
+            self.start_folder,
+            self.stop_folder,
+        )
+
+    def _process_case(self, case_name: str) -> FilteringCaseResult:
+        case_dir = self.input_directory / case_name
+        logger.info("Filtering patient's %s image.", case_name)
+
+        try:
+            image = self._load_image(case_dir)
+        except (DataStructureError, FileNotFoundError, ValueError) as exc:
+            return FilteringCaseResult(case_name=case_name, status='skipped', error=str(exc))
+        except Exception as exc:
+            logger.exception("Patient %s failed while loading image.", case_name)
+            return FilteringCaseResult(case_name=case_name, status='failed', error=str(exc))
+
+        try:
+            filtering = self._create_filter()
+            image_new = filtering.apply(image)
+            output_path = self.output_directory / case_name / self.get_output_filename()
+            image_new.save_as_nifti(output_path)
+            return FilteringCaseResult(case_name=case_name, status='processed', output_path=output_path)
+        except Exception as exc:
+            logger.exception("Patient %s failed during filtering.", case_name)
+            return FilteringCaseResult(case_name=case_name, status='failed', error=str(exc))
+
+    def _load_image(self, case_dir: Path) -> Image:
+        if self.input_data_type == 'dicom':
+            return Image.from_dicom(case_dir, modality=self.modality)
+
+        image_path = find_nifti_file(case_dir, self.nifti_image_name)
+        if image_path is None:
+            raise FileNotFoundError(case_dir / self.nifti_image_name)
+        return Image.from_nifti(image_path)
+
+    def _create_filter(self):
+        if self.filter_type == 'Mean':
+            return create_filter(
+                filtering_method='Mean',
+                padding_type=self.padding_type,
+                support=self.mean_support,
+                dimensionality=self.filter_dimension,
+            )
+        if self.filter_type == 'Laplacian of Gaussian':
+            return create_filter(
+                filtering_method='Laplacian of Gaussian',
+                padding_type=self.padding_type,
+                sigma_mm=self.log_sigma,
+                cutoff=self.log_cutoff,
+                dimensionality=self.filter_dimension,
+            )
+        if self.filter_type == 'Laws Kernels':
+            return create_filter(
+                filtering_method='Laws Kernels',
+                response_map=self.laws_response_map,
+                padding_type=self.padding_type,
+                dimensionality=self.filter_dimension,
+                rotation_invariance=_as_bool(self.laws_rotation_invariance),
+                pooling=self.laws_pooling,
+                energy_map=_as_bool(self.laws_energy_map),
+                distance=self.laws_distance,
+            )
+        if self.filter_type == 'Gabor':
+            return create_filter(
+                filtering_method='Gabor',
+                padding_type=self.padding_type,
+                res_mm=self.gabor_res_mm,
+                sigma_mm=self.gabor_sigma_mm,
+                lambda_mm=self.gabor_lambda_mm,
+                gamma=self.gabor_gamma,
+                theta=self.gabor_theta,
+                rotation_invariance=_as_bool(self.gabor_rotation_invariance),
+                orthogonal_planes=_as_bool(self.gabor_orthogonal_planes),
+            )
+        if self.filter_type == 'Wavelets':
+            return create_filter(
+                filtering_method='Wavelets',
+                dimensionality=self.filter_dimension,
+                padding_type=self.padding_type,
+                wavelet_type=self.wavelet_type,
+                response_map=self.wavelet_response_map,
+                decomposition_level=self.wavelet_decomposition_level,
+                rotation_invariance=_as_bool(self.wavelet_rotation_invariance),
+            )
+        raise InvalidInputParametersError(f"Filter_type {self.filter_type} not supported.")
+
+    def _validate_filter_parameters(self) -> None:
+        if self.filter_type == 'Mean':
+            self.mean_support = _require_positive_int(self.mean_support, "mean_support is required.")
+        elif self.filter_type == 'Laplacian of Gaussian':
+            self.log_sigma = _require_float(self.log_sigma, "log_sigma is required.")
+            self.log_cutoff = _require_float(self.log_cutoff, "log_cutoff is required.")
+        elif self.filter_type == 'Laws Kernels':
+            self.laws_response_map = require_text(self.laws_response_map, "laws_response_map is required.")
+            self.laws_pooling = require_text(self.laws_pooling, "laws_pooling is required.")
+            self.laws_distance = _require_positive_int(self.laws_distance, "laws_distance is required.")
+            self.laws_rotation_invariance = _normalize_enable_disable(self.laws_rotation_invariance)
+            self.laws_energy_map = _normalize_enable_disable(self.laws_energy_map)
+        elif self.filter_type == 'Gabor':
+            self.gabor_res_mm = _require_float(self.gabor_res_mm, "gabor_res_mm is required.")
+            self.gabor_sigma_mm = _require_float(self.gabor_sigma_mm, "gabor_sigma_mm is required.")
+            self.gabor_lambda_mm = _require_float(self.gabor_lambda_mm, "gabor_lambda_mm is required.")
+            self.gabor_gamma = _require_float(self.gabor_gamma, "gabor_gamma is required.")
+            self.gabor_theta = _require_float(self.gabor_theta, "gabor_theta is required.")
+            self.gabor_rotation_invariance = _normalize_enable_disable(self.gabor_rotation_invariance)
+            self.gabor_orthogonal_planes = _normalize_enable_disable(self.gabor_orthogonal_planes)
+        elif self.filter_type == 'Wavelets':
+            self.wavelet_type = require_text(self.wavelet_type, "wavelet_type is required.")
+            self.wavelet_response_map = require_text(self.wavelet_response_map, "wavelet_response_map is required.")
+            self.wavelet_decomposition_level = _require_positive_int(
+                self.wavelet_decomposition_level,
+                "wavelet_decomposition_level is required.",
+            )
+            self.wavelet_rotation_invariance = _normalize_enable_disable(self.wavelet_rotation_invariance)
+        else:
+            raise InvalidInputParametersError(f"Filter_type {self.filter_type} not supported.")
+
+    def _filename_values(self) -> dict:
+        return {
+            'filter_type': self.filter_type,
+            'filter_dimension': self.filter_dimension,
+            'filter_padding_type': self.padding_type,
+            'filter_mean_support': self.mean_support,
+            'filter_log_sigma': self.log_sigma,
+            'filter_log_cutoff': self.log_cutoff,
+            'filter_laws_response_map': self.laws_response_map,
+            'filter_laws_rot_inv': _enable_disable_text(self.laws_rotation_invariance),
+            'filter_laws_pooling': self.laws_pooling,
+            'filter_laws_energy_map': _enable_disable_text(self.laws_energy_map),
+            'filter_laws_distance': self.laws_distance,
+            'filter_wavelet_type': self.wavelet_type,
+            'filter_wavelet_resp_map': self.wavelet_response_map,
+            'filter_wavelet_decomp_lvl': self.wavelet_decomposition_level,
+            'filter_wavelet_rot_inv': _enable_disable_text(self.wavelet_rotation_invariance),
+            'filter_gabor_res_mm': self.gabor_res_mm,
+            'filter_gabor_sigma_mm': self.gabor_sigma_mm,
+            'filter_gabor_lambda_mm': self.gabor_lambda_mm,
+            'filter_gabor_gamma': self.gabor_gamma,
+            'filter_gabor_theta': self.gabor_theta,
+            'filter_gabor_rotinv': _enable_disable_text(self.gabor_rotation_invariance),
+            'filter_gabor_ortho': _enable_disable_text(self.gabor_orthogonal_planes),
+        }
+
+
+def _require_positive_int(value, message: str) -> int:
+    if value is None or str(value).strip() == '':
+        raise InvalidInputParametersError(message)
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        raise InvalidInputParametersError(message)
+    if result <= 0:
+        raise InvalidInputParametersError(message)
+    return result
+
+
+def _require_float(value, message: str) -> float:
+    if value is None or str(value).strip() == '':
+        raise InvalidInputParametersError(message)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise InvalidInputParametersError(message)
+
+
+def _normalize_enable_disable(value) -> str:
+    if isinstance(value, str):
+        text = value.strip()
+        if text in ['Enable', 'Disable']:
+            return text
+        if text.lower() in ['true', 'yes', '1']:
+            return 'Enable'
+        if text.lower() in ['false', 'no', '0']:
+            return 'Disable'
+    return 'Enable' if bool(value) else 'Disable'
+
+
+def _as_bool(value) -> bool:
+    return _normalize_enable_disable(value) == 'Enable'
+
+
+def _enable_disable_text(value) -> str:
+    return _normalize_enable_disable(value)

--- a/zrad/batch/preprocessing.py
+++ b/zrad/batch/preprocessing.py
@@ -13,6 +13,7 @@ from ..preprocessing import ImageResampler, MaskResampler
 from ._utils import (
     find_nifti_file,
     joblib_progress,
+    normalize_common_batch_options,
     normalize_names,
     normalize_optional_text,
     require_text,
@@ -65,30 +66,7 @@ class BatchPreprocessor:
     parallel_backend: str = 'processes'
 
     def validate(self) -> None:
-        self.input_directory = Path(self.input_directory)
-        self.output_directory = Path(self.output_directory)
-        self.input_data_type = str(self.input_data_type).strip().lower()
-        self.modality = str(self.modality).strip().upper()
-        self.parallel_backend = str(self.parallel_backend).strip().lower()
-
-        if self.input_data_type not in ['dicom', 'nifti']:
-            raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
-        if self.modality not in ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']:
-            raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
-        if not self.input_directory.exists():
-            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
-        if not self.input_directory.is_dir():
-            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' is not a directory.")
-
-        try:
-            self.number_of_threads = int(self.number_of_threads)
-        except (TypeError, ValueError):
-            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
-        if self.number_of_threads < 1:
-            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
-
-        if self.parallel_backend not in ['processes', 'threads']:
-            raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
+        normalize_common_batch_options(self)
 
         if self.input_data_type == 'nifti':
             self.nifti_image_name = normalize_optional_text(self.nifti_image_name)
@@ -98,9 +76,6 @@ class BatchPreprocessor:
                 raise InvalidInputParametersError("use_all_structures is only supported for DICOM preprocessing.")
 
         self.structures = normalize_names(self.structures)
-        self.patient_folders = normalize_names(self.patient_folders)
-        self.start_folder = normalize_optional_text(self.start_folder)
-        self.stop_folder = normalize_optional_text(self.stop_folder)
 
         if not self.just_save_as_nifti:
             if self.resample_resolution is None:

--- a/zrad/batch/preprocessing.py
+++ b/zrad/batch/preprocessing.py
@@ -1,0 +1,377 @@
+import contextlib
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+import joblib
+import numpy as np
+from joblib import Parallel, delayed
+
+from ..exceptions import DataStructureError, InvalidInputParametersError
+from ..image import Image
+from ..io import get_all_structure_names, get_dicom_files
+from ..preprocessing import ImageResampler, MaskResampler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PreprocessingCaseResult:
+    case_name: str
+    status: str
+    image_output_path: Path | None = None
+    mask_output_paths: dict[str, Path] = field(default_factory=dict)
+    mask_union_output_path: Path | None = None
+    processed_structures: list[str] = field(default_factory=list)
+    skipped_structures: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class BatchResult:
+    workflow: str
+    case_results: list
+
+    @property
+    def total_count(self) -> int:
+        return len(self.case_results)
+
+    @property
+    def processed_count(self) -> int:
+        return sum(result.status == 'processed' for result in self.case_results)
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(result.status == 'skipped' for result in self.case_results)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(result.status == 'failed' for result in self.case_results)
+
+    @property
+    def errors(self) -> list:
+        return [result for result in self.case_results if result.error]
+
+
+@dataclass
+class BatchPreprocessor:
+    input_directory: str | Path
+    output_directory: str | Path
+    input_data_type: str
+    modality: str
+    number_of_threads: int = 1
+    patient_folders: Sequence[str] | None = None
+    start_folder: str | int | None = None
+    stop_folder: str | int | None = None
+    structures: Sequence[str] | None = None
+    use_all_structures: bool = False
+    nifti_image_name: str | None = None
+    just_save_as_nifti: bool = False
+    resample_resolution: float | None = None
+    resample_dimension: str | None = None
+    image_interpolation_method: str | None = None
+    mask_interpolation_method: str | None = None
+    mask_interpolation_threshold: float = 0.5
+    mask_union: bool = False
+    parallel_backend: str = 'processes'
+
+    def validate(self) -> None:
+        self.input_directory = Path(self.input_directory)
+        self.output_directory = Path(self.output_directory)
+        self.input_data_type = str(self.input_data_type).strip().lower()
+        self.modality = str(self.modality).strip().upper()
+
+        if self.input_data_type not in ['dicom', 'nifti']:
+            raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
+        if self.modality not in ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']:
+            raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
+        if not self.input_directory.exists():
+            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
+        if not self.input_directory.is_dir():
+            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' is not a directory.")
+
+        try:
+            self.number_of_threads = int(self.number_of_threads)
+        except (TypeError, ValueError):
+            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+        if self.number_of_threads < 1:
+            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+
+        if self.parallel_backend not in ['processes', 'threads']:
+            raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
+
+        if self.input_data_type == 'nifti':
+            self.nifti_image_name = _normalize_optional_text(self.nifti_image_name)
+            if not self.nifti_image_name:
+                raise InvalidInputParametersError("nifti_image_name is required for NIfTI preprocessing.")
+            if self.use_all_structures:
+                raise InvalidInputParametersError("use_all_structures is only supported for DICOM preprocessing.")
+
+        self.structures = _normalize_structure_names(self.structures)
+        self.patient_folders = _normalize_structure_names(self.patient_folders)
+        self.start_folder = _normalize_optional_text(self.start_folder)
+        self.stop_folder = _normalize_optional_text(self.stop_folder)
+
+        if not self.just_save_as_nifti:
+            if self.resample_resolution is None:
+                raise InvalidInputParametersError("resample_resolution is required when resampling is enabled.")
+            try:
+                self.resample_resolution = float(self.resample_resolution)
+            except (TypeError, ValueError):
+                raise InvalidInputParametersError("resample_resolution must be a positive number.")
+            if self.resample_resolution <= 0:
+                raise InvalidInputParametersError("resample_resolution must be a positive number.")
+
+            self.resample_dimension = str(self.resample_dimension).strip().upper()
+            if self.resample_dimension not in ['2D', '3D']:
+                raise InvalidInputParametersError("resample_dimension must be '2D' or '3D'.")
+            self.image_interpolation_method = _require_text(
+                self.image_interpolation_method,
+                "image_interpolation_method is required when resampling is enabled.",
+            )
+            self.mask_interpolation_method = _require_text(
+                self.mask_interpolation_method,
+                "mask_interpolation_method is required when resampling is enabled.",
+            )
+            try:
+                self.mask_interpolation_threshold = float(self.mask_interpolation_threshold)
+            except (TypeError, ValueError):
+                raise InvalidInputParametersError("mask_interpolation_threshold must be a number.")
+
+    def plan(self) -> list[str]:
+        self.validate()
+        return self._resolve_patient_folders()
+
+    def run(self, progress_callback: Callable[[int], None] | None = None) -> BatchResult:
+        self.validate()
+        self.output_directory.mkdir(parents=True, exist_ok=True)
+        patient_folders = self._resolve_patient_folders()
+
+        if self.number_of_threads == 1:
+            case_results = []
+            for patient_folder in patient_folders:
+                case_results.append(self._process_case(patient_folder))
+                if progress_callback:
+                    progress_callback(1)
+        else:
+            with _joblib_progress(progress_callback):
+                case_results = Parallel(n_jobs=self.number_of_threads, prefer=self.parallel_backend)(
+                    delayed(self._process_case)(patient_folder) for patient_folder in patient_folders
+                )
+
+        return BatchResult(workflow='preprocessing', case_results=case_results)
+
+    def _resolve_patient_folders(self) -> list[str]:
+        if self.start_folder and self.stop_folder:
+            try:
+                start = int(self.start_folder)
+                stop = int(self.stop_folder)
+            except ValueError:
+                raise InvalidInputParametersError("start_folder and stop_folder must be integers.")
+            return [
+                path.name
+                for path in sorted(self.input_directory.iterdir())
+                if path.is_dir() and path.name.isdigit() and start <= int(path.name) <= stop
+            ]
+
+        if self.patient_folders:
+            return list(self.patient_folders)
+
+        if self.start_folder or self.stop_folder:
+            raise InvalidInputParametersError("start_folder and stop_folder must be provided together.")
+
+        return [
+            path.name
+            for path in sorted(self.input_directory.iterdir())
+            if path.is_dir() and not path.name.startswith('.')
+        ]
+
+    def _process_case(self, case_name: str) -> PreprocessingCaseResult:
+        case_dir = self.input_directory / case_name
+        case_output_dir = self.output_directory / case_name
+        result = PreprocessingCaseResult(case_name=case_name, status='processed')
+        logger.info("Processing patient's %s image.", case_name)
+
+        try:
+            image = self._load_image(case_dir)
+        except (DataStructureError, FileNotFoundError, ValueError) as exc:
+            return PreprocessingCaseResult(case_name=case_name, status='skipped', error=str(exc))
+        except Exception as exc:
+            logger.exception("Patient %s failed while loading image.", case_name)
+            return PreprocessingCaseResult(case_name=case_name, status='failed', error=str(exc))
+
+        try:
+            image_new = image.copy() if self.just_save_as_nifti else self._resample_image(image)
+            image_output_path = case_output_dir / 'image.nii.gz'
+            image_new.save_as_nifti(image_output_path)
+            result.image_output_path = image_output_path
+
+            structure_names, rtstruct_path = self._resolve_structures(case_dir)
+            if structure_names:
+                self._process_masks(case_dir, result, image, structure_names, rtstruct_path)
+            return result
+        except Exception as exc:
+            logger.exception("Patient %s failed during preprocessing.", case_name)
+            result.status = 'failed'
+            result.error = str(exc)
+            return result
+
+    def _load_image(self, case_dir: Path) -> Image:
+        if self.input_data_type == 'dicom':
+            return Image.from_dicom(case_dir, modality=self.modality)
+
+        image_path = _find_nifti_file(case_dir, self.nifti_image_name)
+        if image_path is None:
+            raise FileNotFoundError(case_dir / self.nifti_image_name)
+        return Image.from_nifti(image_path)
+
+    def _resolve_structures(self, case_dir: Path) -> tuple[list[str], str | None]:
+        if self.input_data_type == 'nifti':
+            return list(self.structures or []), None
+
+        rtstructs = get_dicom_files(case_dir, modality='RTSTRUCT')
+        rtstruct_path = rtstructs[0]['file_path'] if rtstructs else None
+        if self.use_all_structures and rtstruct_path:
+            return get_all_structure_names(rtstruct_path), rtstruct_path
+        return list(self.structures or []), rtstruct_path
+
+    def _process_masks(
+        self,
+        case_dir: Path,
+        result: PreprocessingCaseResult,
+        image: Image,
+        structure_names: Sequence[str],
+        rtstruct_path: str | None,
+    ) -> None:
+        mask_union = None
+        case_output_dir = self.output_directory / result.case_name
+
+        for structure_name in structure_names:
+            try:
+                mask = self._load_mask(case_dir, structure_name, image, rtstruct_path)
+            except Exception as exc:
+                result.skipped_structures.append(structure_name)
+                logger.warning("Skipping patient's %s ROI %s: %s", result.case_name, structure_name, exc)
+                continue
+
+            if mask is None or mask.array is None:
+                result.skipped_structures.append(structure_name)
+                continue
+
+            logger.info("Processing patient's %s ROI: %s.", result.case_name, structure_name)
+            mask_new = mask.copy() if self.just_save_as_nifti else self._resample_mask(mask)
+            mask_output_path = case_output_dir / f'{structure_name}.nii.gz'
+            mask_new.save_as_nifti(mask_output_path)
+
+            result.mask_output_paths[structure_name] = mask_output_path
+            result.processed_structures.append(structure_name)
+
+            if self.mask_union:
+                if mask_union:
+                    mask_union.array = np.bitwise_or(
+                        _binary_mask_array(mask_union.array),
+                        _binary_mask_array(mask_new.array),
+                    ).astype(np.int16)
+                else:
+                    mask_union = mask_new.copy()
+                    mask_union.array = _binary_mask_array(mask_union.array)
+
+        if mask_union:
+            mask_union_output_path = case_output_dir / 'mask_union.nii.gz'
+            mask_union.save_as_nifti(mask_union_output_path)
+            result.mask_union_output_path = mask_union_output_path
+
+    def _load_mask(
+        self,
+        case_dir: Path,
+        structure_name: str,
+        image: Image,
+        rtstruct_path: str | None,
+    ) -> Image | None:
+        if self.input_data_type == 'dicom':
+            if not rtstruct_path:
+                return None
+            return Image.from_dicom_mask(rtstruct_path=rtstruct_path, structure_name=structure_name, reference=image)
+
+        mask_path = _find_nifti_file(case_dir, structure_name)
+        if mask_path is None:
+            return None
+        return Image.from_nifti_mask(mask_path, reference=image)
+
+    def _resample_image(self, image: Image) -> Image:
+        return ImageResampler(
+            resolution=self._target_resolution(image),
+            method=self.image_interpolation_method,
+            intensity_rounding='nearest_integer' if self.modality == 'CT' else None,
+        ).apply(image)
+
+    def _resample_mask(self, mask: Image) -> Image:
+        return MaskResampler(
+            resolution=self._target_resolution(mask),
+            method=self.mask_interpolation_method,
+            partial_volume_threshold=self.mask_interpolation_threshold,
+        ).apply(mask)
+
+    def _target_resolution(self, image: Image) -> tuple[float, float, float]:
+        if self.resample_dimension == '3D':
+            return (self.resample_resolution, self.resample_resolution, self.resample_resolution)
+        if self.resample_dimension == '2D':
+            return (self.resample_resolution, self.resample_resolution, image.spacing[2])
+        raise ValueError(f"Resample dimension '{self.resample_dimension}' is not supported.")
+
+
+def _normalize_optional_text(value) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _require_text(value, message: str) -> str:
+    text = _normalize_optional_text(value)
+    if not text:
+        raise InvalidInputParametersError(message)
+    return text
+
+
+def _normalize_structure_names(values: Sequence[str] | str | None) -> list[str] | None:
+    if values is None:
+        return None
+    if isinstance(values, str):
+        values = values.split(',')
+    normalized = [str(value).strip() for value in values if str(value).strip()]
+    return normalized or None
+
+
+def _find_nifti_file(directory: Path, name: str | None) -> Path | None:
+    if name is None:
+        return None
+    base_path = directory / name
+    for candidate in [base_path.with_suffix(base_path.suffix + '.gz'), base_path.with_suffix('.nii'), base_path]:
+        if candidate.exists():
+            return candidate
+    nii_gz_path = directory / f'{name}.nii.gz'
+    if nii_gz_path.exists():
+        return nii_gz_path
+    return None
+
+
+def _binary_mask_array(array):
+    return np.where(array > 0, 1, 0).astype(np.int16)
+
+
+@contextlib.contextmanager
+def _joblib_progress(progress_callback: Callable[[int], None] | None = None):
+    class ProgressBatchCompletionCallback(joblib.parallel.BatchCompletionCallBack):
+        def __call__(self, *args, **kwargs):
+            if progress_callback:
+                progress_callback(self.batch_size)
+            return super().__call__(*args, **kwargs)
+
+    old_batch_callback = joblib.parallel.BatchCompletionCallBack
+    joblib.parallel.BatchCompletionCallBack = ProgressBatchCompletionCallback
+    try:
+        yield
+    finally:
+        joblib.parallel.BatchCompletionCallBack = old_batch_callback

--- a/zrad/batch/preprocessing.py
+++ b/zrad/batch/preprocessing.py
@@ -1,10 +1,8 @@
-import contextlib
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Sequence
 
-import joblib
 import numpy as np
 from joblib import Parallel, delayed
 
@@ -12,6 +10,15 @@ from ..exceptions import DataStructureError, InvalidInputParametersError
 from ..image import Image
 from ..io import get_all_structure_names, get_dicom_files
 from ..preprocessing import ImageResampler, MaskResampler
+from ._utils import (
+    find_nifti_file,
+    joblib_progress,
+    normalize_names,
+    normalize_optional_text,
+    require_text,
+    resolve_patient_folders,
+)
+from .results import BatchResult
 
 logger = logging.getLogger(__name__)
 
@@ -29,33 +36,14 @@ class PreprocessingCaseResult:
 
 
 @dataclass
-class BatchResult:
-    workflow: str
-    case_results: list
-
-    @property
-    def total_count(self) -> int:
-        return len(self.case_results)
-
-    @property
-    def processed_count(self) -> int:
-        return sum(result.status == 'processed' for result in self.case_results)
-
-    @property
-    def skipped_count(self) -> int:
-        return sum(result.status == 'skipped' for result in self.case_results)
-
-    @property
-    def failed_count(self) -> int:
-        return sum(result.status == 'failed' for result in self.case_results)
-
-    @property
-    def errors(self) -> list:
-        return [result for result in self.case_results if result.error]
-
-
-@dataclass
 class BatchPreprocessor:
+    """Run preprocessing over many case folders and write NIfTI outputs.
+
+    ``validate()`` normalizes public attributes in place. After validation,
+    directories are ``Path`` objects, ``input_data_type`` is lower-case, modality
+    is upper-case, and comma-separated folders/structures are stored as lists.
+    """
+
     input_directory: str | Path
     output_directory: str | Path
     input_data_type: str
@@ -81,6 +69,7 @@ class BatchPreprocessor:
         self.output_directory = Path(self.output_directory)
         self.input_data_type = str(self.input_data_type).strip().lower()
         self.modality = str(self.modality).strip().upper()
+        self.parallel_backend = str(self.parallel_backend).strip().lower()
 
         if self.input_data_type not in ['dicom', 'nifti']:
             raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
@@ -102,16 +91,16 @@ class BatchPreprocessor:
             raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
 
         if self.input_data_type == 'nifti':
-            self.nifti_image_name = _normalize_optional_text(self.nifti_image_name)
+            self.nifti_image_name = normalize_optional_text(self.nifti_image_name)
             if not self.nifti_image_name:
                 raise InvalidInputParametersError("nifti_image_name is required for NIfTI preprocessing.")
             if self.use_all_structures:
                 raise InvalidInputParametersError("use_all_structures is only supported for DICOM preprocessing.")
 
-        self.structures = _normalize_structure_names(self.structures)
-        self.patient_folders = _normalize_structure_names(self.patient_folders)
-        self.start_folder = _normalize_optional_text(self.start_folder)
-        self.stop_folder = _normalize_optional_text(self.stop_folder)
+        self.structures = normalize_names(self.structures)
+        self.patient_folders = normalize_names(self.patient_folders)
+        self.start_folder = normalize_optional_text(self.start_folder)
+        self.stop_folder = normalize_optional_text(self.stop_folder)
 
         if not self.just_save_as_nifti:
             if self.resample_resolution is None:
@@ -126,11 +115,11 @@ class BatchPreprocessor:
             self.resample_dimension = str(self.resample_dimension).strip().upper()
             if self.resample_dimension not in ['2D', '3D']:
                 raise InvalidInputParametersError("resample_dimension must be '2D' or '3D'.")
-            self.image_interpolation_method = _require_text(
+            self.image_interpolation_method = require_text(
                 self.image_interpolation_method,
                 "image_interpolation_method is required when resampling is enabled.",
             )
-            self.mask_interpolation_method = _require_text(
+            self.mask_interpolation_method = require_text(
                 self.mask_interpolation_method,
                 "mask_interpolation_method is required when resampling is enabled.",
             )
@@ -155,7 +144,7 @@ class BatchPreprocessor:
                 if progress_callback:
                     progress_callback(1)
         else:
-            with _joblib_progress(progress_callback):
+            with joblib_progress(progress_callback):
                 case_results = Parallel(n_jobs=self.number_of_threads, prefer=self.parallel_backend)(
                     delayed(self._process_case)(patient_folder) for patient_folder in patient_folders
                 )
@@ -163,29 +152,12 @@ class BatchPreprocessor:
         return BatchResult(workflow='preprocessing', case_results=case_results)
 
     def _resolve_patient_folders(self) -> list[str]:
-        if self.start_folder and self.stop_folder:
-            try:
-                start = int(self.start_folder)
-                stop = int(self.stop_folder)
-            except ValueError:
-                raise InvalidInputParametersError("start_folder and stop_folder must be integers.")
-            return [
-                path.name
-                for path in sorted(self.input_directory.iterdir())
-                if path.is_dir() and path.name.isdigit() and start <= int(path.name) <= stop
-            ]
-
-        if self.patient_folders:
-            return list(self.patient_folders)
-
-        if self.start_folder or self.stop_folder:
-            raise InvalidInputParametersError("start_folder and stop_folder must be provided together.")
-
-        return [
-            path.name
-            for path in sorted(self.input_directory.iterdir())
-            if path.is_dir() and not path.name.startswith('.')
-        ]
+        return resolve_patient_folders(
+            self.input_directory,
+            self.patient_folders,
+            self.start_folder,
+            self.stop_folder,
+        )
 
     def _process_case(self, case_name: str) -> PreprocessingCaseResult:
         case_dir = self.input_directory / case_name
@@ -221,7 +193,7 @@ class BatchPreprocessor:
         if self.input_data_type == 'dicom':
             return Image.from_dicom(case_dir, modality=self.modality)
 
-        image_path = _find_nifti_file(case_dir, self.nifti_image_name)
+        image_path = find_nifti_file(case_dir, self.nifti_image_name)
         if image_path is None:
             raise FileNotFoundError(case_dir / self.nifti_image_name)
         return Image.from_nifti(image_path)
@@ -294,7 +266,7 @@ class BatchPreprocessor:
                 return None
             return Image.from_dicom_mask(rtstruct_path=rtstruct_path, structure_name=structure_name, reference=image)
 
-        mask_path = _find_nifti_file(case_dir, structure_name)
+        mask_path = find_nifti_file(case_dir, structure_name)
         if mask_path is None:
             return None
         return Image.from_nifti_mask(mask_path, reference=image)
@@ -321,57 +293,5 @@ class BatchPreprocessor:
         raise ValueError(f"Resample dimension '{self.resample_dimension}' is not supported.")
 
 
-def _normalize_optional_text(value) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
-
-def _require_text(value, message: str) -> str:
-    text = _normalize_optional_text(value)
-    if not text:
-        raise InvalidInputParametersError(message)
-    return text
-
-
-def _normalize_structure_names(values: Sequence[str] | str | None) -> list[str] | None:
-    if values is None:
-        return None
-    if isinstance(values, str):
-        values = values.split(',')
-    normalized = [str(value).strip() for value in values if str(value).strip()]
-    return normalized or None
-
-
-def _find_nifti_file(directory: Path, name: str | None) -> Path | None:
-    if name is None:
-        return None
-    base_path = directory / name
-    for candidate in [base_path.with_suffix(base_path.suffix + '.gz'), base_path.with_suffix('.nii'), base_path]:
-        if candidate.exists():
-            return candidate
-    nii_gz_path = directory / f'{name}.nii.gz'
-    if nii_gz_path.exists():
-        return nii_gz_path
-    return None
-
-
 def _binary_mask_array(array):
     return np.where(array > 0, 1, 0).astype(np.int16)
-
-
-@contextlib.contextmanager
-def _joblib_progress(progress_callback: Callable[[int], None] | None = None):
-    class ProgressBatchCompletionCallback(joblib.parallel.BatchCompletionCallBack):
-        def __call__(self, *args, **kwargs):
-            if progress_callback:
-                progress_callback(self.batch_size)
-            return super().__call__(*args, **kwargs)
-
-    old_batch_callback = joblib.parallel.BatchCompletionCallBack
-    joblib.parallel.BatchCompletionCallBack = ProgressBatchCompletionCallback
-    try:
-        yield
-    finally:
-        joblib.parallel.BatchCompletionCallBack = old_batch_callback

--- a/zrad/batch/preprocessing.py
+++ b/zrad/batch/preprocessing.py
@@ -26,6 +26,30 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PreprocessingCaseResult:
+    """Per-case result returned by ``BatchPreprocessor``.
+
+    Attributes
+    ----------
+    case_name : str
+        Name of the case folder.
+    status : {"processed", "skipped", "failed"}
+        Processing status for the case.
+    image_output_path : pathlib.Path or None, optional
+        Path to the written image file, if image export succeeded.
+    mask_output_paths : dict of str to pathlib.Path
+        Written mask paths keyed by structure name.
+    mask_union_output_path : pathlib.Path or None, optional
+        Path to ``mask_union.nii.gz`` when mask union output is enabled and
+        at least one mask was written.
+    processed_structures : list of str
+        Structure names that were loaded and written successfully.
+    skipped_structures : list of str
+        Structure names that were requested but could not be written.
+    error : str or None, optional
+        Case-level error message. Structure-level mask failures are usually
+        recorded in ``skipped_structures`` instead.
+    """
+
     case_name: str
     status: str
     image_output_path: Path | None = None
@@ -40,9 +64,60 @@ class PreprocessingCaseResult:
 class BatchPreprocessor:
     """Run preprocessing over many case folders and write NIfTI outputs.
 
+    ``BatchPreprocessor`` is the batch counterpart to the lower-level
+    preprocessing classes. It discovers case folders, loads DICOM or NIfTI
+    images and masks, optionally resamples them, and writes one output folder
+    per case. The API is save-to-disk only; images and masks are summarized in
+    the returned ``BatchResult`` rather than returned in memory.
+
+    Parameters
+    ----------
+    input_directory : str or pathlib.Path
+        Directory containing one subfolder per case.
+    output_directory : str or pathlib.Path
+        Directory where preprocessed case folders are written.
+    input_data_type : {"dicom", "nifti"}
+        Input format. Values are normalized to lower-case during validation.
+    modality : {"CT", "MRI", "PET", "MG", "RTDOSE"}
+        Image modality used by the image reader. Values are normalized to
+        upper-case during validation.
+    number_of_threads : int, optional
+        Number of cases to process in parallel. The default is ``1``.
+    patient_folders : sequence of str or str, optional
+        Explicit case folders to process. Comma-separated strings are accepted.
+    start_folder, stop_folder : str or int, optional
+        Inclusive numeric folder range. Both values must be provided together.
+    structures : sequence of str or str, optional
+        Structure names to process. For NIfTI input these are mask file names.
+    use_all_structures : bool, optional
+        For DICOM input, process all structures found in the RTSTRUCT.
+    nifti_image_name : str, optional
+        Image file name or stem used for NIfTI input.
+    just_save_as_nifti : bool, optional
+        If ``True``, convert inputs to NIfTI without resampling.
+    resample_resolution : float, optional
+        Target in-plane or isotropic resolution in millimetres when resampling.
+    resample_dimension : {"2D", "3D"}, optional
+        Use ``"2D"`` to keep the original slice spacing or ``"3D"`` for
+        isotropic resampling.
+    image_interpolation_method : str, optional
+        Interpolation method for images when resampling.
+    mask_interpolation_method : str, optional
+        Interpolation method for masks when resampling.
+    mask_interpolation_threshold : float, optional
+        Threshold applied to interpolated masks. The default is ``0.5``.
+    mask_union : bool, optional
+        If ``True``, write a binary union of all successfully processed masks.
+    parallel_backend : {"processes", "threads"}, optional
+        Joblib backend preference used when ``number_of_threads`` is greater
+        than one. The default is ``"processes"``.
+
+    Notes
+    -----
     ``validate()`` normalizes public attributes in place. After validation,
-    directories are ``Path`` objects, ``input_data_type`` is lower-case, modality
-    is upper-case, and comma-separated folders/structures are stored as lists.
+    directories are ``Path`` objects, ``input_data_type`` is lower-case,
+    modality is upper-case, and comma-separated folders or structures are
+    stored as lists.
     """
 
     input_directory: str | Path
@@ -66,6 +141,15 @@ class BatchPreprocessor:
     parallel_backend: str = 'processes'
 
     def validate(self) -> None:
+        """Validate and normalize preprocessing configuration.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If the input directory, data type, modality, folder selection,
+            structure selection, threading, backend, or resampling settings are
+            invalid.
+        """
         normalize_common_batch_options(self)
 
         if self.input_data_type == 'nifti':
@@ -104,10 +188,45 @@ class BatchPreprocessor:
                 raise InvalidInputParametersError("mask_interpolation_threshold must be a number.")
 
     def plan(self) -> list[str]:
+        """Return the case folders selected for preprocessing.
+
+        Returns
+        -------
+        folders : list of str
+            Deterministically ordered case folder names selected by
+            ``patient_folders`` or the numeric ``start_folder`` /
+            ``stop_folder`` range. If neither option is set, all non-hidden
+            subfolders are returned.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If validation fails before folder selection.
+        """
         self.validate()
         return self._resolve_patient_folders()
 
     def run(self, progress_callback: Callable[[int], None] | None = None) -> BatchResult:
+        """Run preprocessing and write NIfTI outputs.
+
+        Parameters
+        ----------
+        progress_callback : callable, optional
+            Function called as ``progress_callback(step_count)`` after cases
+            complete. ``step_count`` may be greater than one during parallel
+            execution.
+
+        Returns
+        -------
+        result : BatchResult
+            Aggregate result with one ``PreprocessingCaseResult`` per selected
+            case.
+
+        Notes
+        -----
+        Case-level failures are recorded in the returned result and do not stop
+        the batch.
+        """
         self.validate()
         self.output_directory.mkdir(parents=True, exist_ok=True)
         patient_folders = self._resolve_patient_folders()

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -90,9 +90,7 @@ class BatchRadiomicsExtractor:
         if self.aggregation_dimension not in ['2D', '2.5D', '3D']:
             raise InvalidInputParametersError("aggregation_dimension must be '2D', '2.5D', or '3D'.")
         if self.aggregation_method not in ['MERG', 'AVER', 'SLICE_MERG', 'DIR_MERG']:
-            raise InvalidInputParametersError(
-                "aggregation_method must be one of MERG, AVER, SLICE_MERG, or DIR_MERG."
-            )
+            raise InvalidInputParametersError("aggregation_method must be one of MERG, AVER, SLICE_MERG, or DIR_MERG.")
         if not self.input_directory.exists():
             raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
         if not self.input_directory.is_dir():

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -129,8 +129,8 @@ class BatchRadiomicsExtractor:
         if self.slice_weighting and self.slice_median:
             raise InvalidInputParametersError("slice_weighting and slice_median cannot both be enabled.")
 
-        self._validate_discretization()
         self.intensity_range = _normalize_intensity_range(self.intensity_range)
+        self._validate_discretization()
         self.outlier_range = _normalize_positive_float(self.outlier_range, "outlier_range must be positive.")
 
     def plan(self) -> list[str]:
@@ -215,7 +215,9 @@ class BatchRadiomicsExtractor:
             return result, feature_rows
 
         result.status = 'skipped'
-        if not result.skipped_structures:
+        if result.skipped_structures:
+            result.error = "No structures were successfully processed for radiomics extraction."
+        else:
             result.error = "No structures were available for radiomics extraction."
         return result, feature_rows
 
@@ -296,6 +298,8 @@ class BatchRadiomicsExtractor:
             self.bin_size = None
         elif self.discretization_method == 'Bin Size':
             self.bin_size = _require_positive_float(self.bin_size, "bin_size is required.")
+            if self.intensity_range is None:
+                raise InvalidInputParametersError("Bin Size discretization requires intensity_range.")
             self.number_of_bins = None
         else:
             raise InvalidInputParametersError("discretization_method must be 'Number of Bins' or 'Bin Size'.")

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -15,6 +15,7 @@ from ..radiomics import Radiomics
 from ._utils import (
     find_nifti_file,
     joblib_progress,
+    normalize_common_batch_options,
     normalize_names,
     normalize_optional_text,
     require_text,
@@ -64,11 +65,7 @@ class BatchRadiomicsExtractor:
     parallel_backend: str = 'processes'
 
     def validate(self) -> None:
-        self.input_directory = Path(self.input_directory)
-        self.output_directory = Path(self.output_directory)
-        self.input_data_type = str(self.input_data_type).strip().lower()
-        self.modality = str(self.modality).strip().upper()
-        self.parallel_backend = str(self.parallel_backend).strip().lower()
+        normalize_common_batch_options(self)
         self.aggregation_dimension = require_text(
             self.aggregation_dimension,
             "aggregation_dimension is required.",
@@ -83,32 +80,12 @@ class BatchRadiomicsExtractor:
         )
         self.output_filename = require_text(self.output_filename, "output_filename is required.")
 
-        if self.input_data_type not in ['dicom', 'nifti']:
-            raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
-        if self.modality not in ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']:
-            raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
         if self.aggregation_dimension not in ['2D', '2.5D', '3D']:
             raise InvalidInputParametersError("aggregation_dimension must be '2D', '2.5D', or '3D'.")
         if self.aggregation_method not in ['MERG', 'AVER', 'SLICE_MERG', 'DIR_MERG']:
             raise InvalidInputParametersError("aggregation_method must be one of MERG, AVER, SLICE_MERG, or DIR_MERG.")
-        if not self.input_directory.exists():
-            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
-        if not self.input_directory.is_dir():
-            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' is not a directory.")
-
-        try:
-            self.number_of_threads = int(self.number_of_threads)
-        except (TypeError, ValueError):
-            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
-        if self.number_of_threads < 1:
-            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
-        if self.parallel_backend not in ['processes', 'threads']:
-            raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
 
         self.structures = normalize_names(self.structures)
-        self.patient_folders = normalize_names(self.patient_folders)
-        self.start_folder = normalize_optional_text(self.start_folder)
-        self.stop_folder = normalize_optional_text(self.stop_folder)
         self.nifti_filtered_image_name = normalize_optional_text(self.nifti_filtered_image_name)
 
         if self.input_data_type == 'nifti':

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -306,7 +306,7 @@ class BatchRadiomicsExtractor:
 def _write_radiomics_csv(file_path: Path, features: list[dict]) -> None:
     file_path.parent.mkdir(parents=True, exist_ok=True)
     if not features:
-        file_path.touch()
+        file_path.write_text('')
         return
 
     fieldnames = []

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -1,0 +1,380 @@
+import csv
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+import numpy as np
+from joblib import Parallel, delayed
+
+from ..exceptions import DataStructureError, InvalidInputParametersError
+from ..image import Image
+from ..io import get_all_structure_names, get_dicom_files
+from ..preprocessing import IntensityMaskBuilder, Resegmenter, RoiData, TextureDiscretizer
+from ..radiomics import Radiomics
+from ._utils import (
+    find_nifti_file,
+    joblib_progress,
+    normalize_names,
+    normalize_optional_text,
+    require_text,
+    resolve_patient_folders,
+)
+from .results import BatchResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RadiomicsCaseResult:
+    case_name: str
+    status: str
+    processed_structures: list[str] = field(default_factory=list)
+    skipped_structures: list[str] = field(default_factory=list)
+    feature_count: int = 0
+    error: str | None = None
+
+
+@dataclass
+class BatchRadiomicsExtractor:
+    """Extract radiomics features for many case folders and write one CSV."""
+
+    input_directory: str | Path
+    output_directory: str | Path
+    input_data_type: str
+    modality: str
+    aggregation_dimension: str
+    aggregation_method: str
+    discretization_method: str
+    number_of_threads: int = 1
+    patient_folders: Sequence[str] | None = None
+    start_folder: str | int | None = None
+    stop_folder: str | int | None = None
+    structures: Sequence[str] | None = None
+    use_all_structures: bool = False
+    nifti_image_name: str | None = None
+    nifti_filtered_image_name: str | None = None
+    slice_weighting: bool = False
+    slice_median: bool = False
+    number_of_bins: int | str | None = None
+    bin_size: float | str | None = None
+    intensity_range: Sequence[float] | None = None
+    outlier_range: float | str | None = None
+    output_filename: str = 'radiomics.csv'
+    parallel_backend: str = 'processes'
+
+    def validate(self) -> None:
+        self.input_directory = Path(self.input_directory)
+        self.output_directory = Path(self.output_directory)
+        self.input_data_type = str(self.input_data_type).strip().lower()
+        self.modality = str(self.modality).strip().upper()
+        self.parallel_backend = str(self.parallel_backend).strip().lower()
+        self.aggregation_dimension = require_text(
+            self.aggregation_dimension,
+            "aggregation_dimension is required.",
+        ).upper()
+        self.aggregation_method = require_text(
+            self.aggregation_method,
+            "aggregation_method is required.",
+        ).upper()
+        self.discretization_method = require_text(
+            self.discretization_method,
+            "discretization_method is required.",
+        )
+        self.output_filename = require_text(self.output_filename, "output_filename is required.")
+
+        if self.input_data_type not in ['dicom', 'nifti']:
+            raise InvalidInputParametersError("input_data_type must be 'dicom' or 'nifti'.")
+        if self.modality not in ['CT', 'MRI', 'PET', 'MG', 'RTDOSE']:
+            raise InvalidInputParametersError("modality must be one of CT, MRI, PET, MG, or RTDOSE.")
+        if self.aggregation_dimension not in ['2D', '2.5D', '3D']:
+            raise InvalidInputParametersError("aggregation_dimension must be '2D', '2.5D', or '3D'.")
+        if self.aggregation_method not in ['MERG', 'AVER', 'SLICE_MERG', 'DIR_MERG']:
+            raise InvalidInputParametersError(
+                "aggregation_method must be one of MERG, AVER, SLICE_MERG, or DIR_MERG."
+            )
+        if not self.input_directory.exists():
+            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' does not exist.")
+        if not self.input_directory.is_dir():
+            raise InvalidInputParametersError(f"Input directory '{self.input_directory}' is not a directory.")
+
+        try:
+            self.number_of_threads = int(self.number_of_threads)
+        except (TypeError, ValueError):
+            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+        if self.number_of_threads < 1:
+            raise InvalidInputParametersError("number_of_threads must be a positive integer.")
+        if self.parallel_backend not in ['processes', 'threads']:
+            raise InvalidInputParametersError("parallel_backend must be 'processes' or 'threads'.")
+
+        self.structures = normalize_names(self.structures)
+        self.patient_folders = normalize_names(self.patient_folders)
+        self.start_folder = normalize_optional_text(self.start_folder)
+        self.stop_folder = normalize_optional_text(self.stop_folder)
+        self.nifti_filtered_image_name = normalize_optional_text(self.nifti_filtered_image_name)
+
+        if self.input_data_type == 'nifti':
+            self.nifti_image_name = normalize_optional_text(self.nifti_image_name)
+            if not self.nifti_image_name:
+                raise InvalidInputParametersError("nifti_image_name is required for NIfTI radiomics.")
+            if self.use_all_structures:
+                raise InvalidInputParametersError("use_all_structures is only supported for DICOM radiomics.")
+            if not self.structures:
+                raise InvalidInputParametersError("structures are required for NIfTI radiomics.")
+        elif not self.use_all_structures and not self.structures:
+            raise InvalidInputParametersError("DICOM radiomics requires structures or use_all_structures=True.")
+
+        self.slice_weighting = _as_bool(self.slice_weighting)
+        self.slice_median = _as_bool(self.slice_median)
+        if self.slice_weighting and self.slice_median:
+            raise InvalidInputParametersError("slice_weighting and slice_median cannot both be enabled.")
+
+        self._validate_discretization()
+        self.intensity_range = _normalize_intensity_range(self.intensity_range)
+        self.outlier_range = _normalize_positive_float(self.outlier_range, "outlier_range must be positive.")
+
+    def plan(self) -> list[str]:
+        self.validate()
+        return self._resolve_patient_folders()
+
+    def run(self, progress_callback: Callable[[int], None] | None = None) -> BatchResult:
+        self.validate()
+        self.output_directory.mkdir(parents=True, exist_ok=True)
+        patient_folders = self._resolve_patient_folders()
+
+        if self.number_of_threads == 1:
+            processed = []
+            for patient_folder in patient_folders:
+                processed.append(self._process_case(patient_folder))
+                if progress_callback:
+                    progress_callback(1)
+        else:
+            with joblib_progress(progress_callback):
+                processed = Parallel(n_jobs=self.number_of_threads, prefer=self.parallel_backend)(
+                    delayed(self._process_case)(patient_folder) for patient_folder in patient_folders
+                )
+
+        case_results = [case_result for case_result, _features in processed]
+        feature_rows = [row for _case_result, features in processed for row in features]
+        _write_radiomics_csv(self.output_directory / self.output_filename, feature_rows)
+        return BatchResult(workflow='radiomics', case_results=case_results)
+
+    def _resolve_patient_folders(self) -> list[str]:
+        return resolve_patient_folders(
+            self.input_directory,
+            self.patient_folders,
+            self.start_folder,
+            self.stop_folder,
+        )
+
+    def _process_case(self, case_name: str) -> tuple[RadiomicsCaseResult, list[dict]]:
+        case_dir = self.input_directory / case_name
+        result = RadiomicsCaseResult(case_name=case_name, status='processed')
+        feature_rows = []
+        logger.info("Processing patient: %s.", case_name)
+
+        try:
+            image, filtered_image = self._load_images(case_dir)
+        except (DataStructureError, FileNotFoundError, ValueError) as exc:
+            return RadiomicsCaseResult(case_name=case_name, status='skipped', error=str(exc)), []
+        except Exception as exc:
+            logger.exception("Patient %s failed while loading image.", case_name)
+            return RadiomicsCaseResult(case_name=case_name, status='failed', error=str(exc)), []
+
+        try:
+            structure_names, rtstruct_path = self._resolve_structures(case_dir)
+        except Exception as exc:
+            logger.exception("Patient %s failed while resolving structures.", case_name)
+            return RadiomicsCaseResult(case_name=case_name, status='failed', error=str(exc)), []
+
+        for structure_name in structure_names:
+            try:
+                mask = self._load_mask(case_dir, structure_name, image, rtstruct_path)
+                if mask is None or mask.array is None or not np.any(mask.array):
+                    result.skipped_structures.append(structure_name)
+                    continue
+
+                logger.info("Processing patient: %s with ROI: %s.", case_name, structure_name)
+                features = self._extract_structure_features(image, filtered_image, mask)
+            except (DataStructureError, ValueError) as exc:
+                logger.warning("Patient %s with mask %s skipped: %s", case_name, structure_name, exc)
+                result.skipped_structures.append(structure_name)
+                continue
+            except Exception:
+                logger.exception("Patient %s failed for mask %s.", case_name, structure_name)
+                result.skipped_structures.append(structure_name)
+                continue
+
+            result.feature_count += len(features)
+            features['pat_id'] = case_name
+            features['mask_id'] = structure_name
+            feature_rows.append(features)
+            result.processed_structures.append(structure_name)
+
+        if result.processed_structures:
+            return result, feature_rows
+
+        result.status = 'skipped'
+        if not result.skipped_structures:
+            result.error = "No structures were available for radiomics extraction."
+        return result, feature_rows
+
+    def _load_images(self, case_dir: Path) -> tuple[Image, Image | None]:
+        image = self._load_image(case_dir, self.nifti_image_name)
+        filtered_image = None
+        if self.input_data_type == 'nifti' and self.nifti_filtered_image_name:
+            filtered_image = self._load_image(case_dir, self.nifti_filtered_image_name)
+        return image, filtered_image
+
+    def _load_image(self, case_dir: Path, nifti_name: str | None = None) -> Image:
+        if self.input_data_type == 'dicom':
+            return Image.from_dicom(case_dir, modality=self.modality)
+
+        image_path = find_nifti_file(case_dir, nifti_name)
+        if image_path is None:
+            raise FileNotFoundError(case_dir / str(nifti_name))
+        return Image.from_nifti(image_path)
+
+    def _resolve_structures(self, case_dir: Path) -> tuple[list[str], str | None]:
+        if self.input_data_type == 'nifti':
+            return list(self.structures or []), None
+
+        rtstructs = get_dicom_files(case_dir, modality='RTSTRUCT')
+        rtstruct_path = rtstructs[0]['file_path'] if rtstructs else None
+        if self.use_all_structures:
+            if not rtstruct_path:
+                return [], None
+            return get_all_structure_names(rtstruct_path), rtstruct_path
+        return list(self.structures or []), rtstruct_path
+
+    def _load_mask(
+        self,
+        case_dir: Path,
+        structure_name: str,
+        image: Image,
+        rtstruct_path: str | None,
+    ) -> Image | None:
+        if self.input_data_type == 'dicom':
+            if not rtstruct_path:
+                return None
+            return Image.from_dicom_mask(rtstruct_path=rtstruct_path, structure_name=structure_name, reference=image)
+
+        mask_path = find_nifti_file(case_dir, structure_name)
+        if mask_path is None:
+            return None
+        return Image.from_nifti_mask(mask_path, reference=image)
+
+    def _extract_structure_features(self, image: Image, filtered_image: Image | None, mask: Image) -> dict:
+        roi_data = IntensityMaskBuilder().apply(
+            RoiData(
+                image=image,
+                filtered_image=filtered_image,
+                morphological_mask=mask,
+            )
+        )
+        roi_data = Resegmenter(
+            intensity_range=self.intensity_range,
+            outlier_range=self.outlier_range,
+        ).apply(roi_data)
+        roi_data = TextureDiscretizer(
+            number_of_bins=self.number_of_bins,
+            bin_size=self.bin_size,
+        ).apply(roi_data)
+        return Radiomics(
+            aggr_dim=self.aggregation_dimension,
+            aggr_method=self.aggregation_method,
+            slice_weighting=self.slice_weighting,
+            slice_median=self.slice_median,
+        ).extract_features(
+            roi_data=roi_data,
+            include_metadata=True,
+        )
+
+    def _validate_discretization(self) -> None:
+        if self.discretization_method == 'Number of Bins':
+            self.number_of_bins = _require_positive_int(self.number_of_bins, "number_of_bins is required.")
+            self.bin_size = None
+        elif self.discretization_method == 'Bin Size':
+            self.bin_size = _require_positive_float(self.bin_size, "bin_size is required.")
+            self.number_of_bins = None
+        else:
+            raise InvalidInputParametersError("discretization_method must be 'Number of Bins' or 'Bin Size'.")
+
+
+def _write_radiomics_csv(file_path: Path, features: list[dict]) -> None:
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    if not features:
+        file_path.touch()
+        return
+
+    fieldnames = []
+    for key in ("pat_id", "mask_id", "bounding_box_min", "no_voxels", "no_bins"):
+        if any(key in row for row in features):
+            fieldnames.append(key)
+
+    for row in features:
+        for key in row.keys():
+            if key not in fieldnames:
+                fieldnames.append(key)
+
+    with open(file_path, "w", newline="") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(features)
+
+
+def _require_positive_int(value, message: str) -> int:
+    if value is None or str(value).strip() == '':
+        raise InvalidInputParametersError(message)
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        raise InvalidInputParametersError(message)
+    if result <= 0:
+        raise InvalidInputParametersError(message)
+    return result
+
+
+def _require_positive_float(value, message: str) -> float:
+    result = _normalize_positive_float(value, message)
+    if result is None:
+        raise InvalidInputParametersError(message)
+    return result
+
+
+def _normalize_positive_float(value, message: str) -> float | None:
+    if value is None or str(value).strip() == '':
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        raise InvalidInputParametersError(message)
+    if not np.isfinite(result) or result <= 0:
+        raise InvalidInputParametersError(message)
+    return result
+
+
+def _normalize_intensity_range(values: Sequence[float] | None) -> tuple[float, float] | None:
+    if values is None:
+        return None
+    if isinstance(values, str):
+        values = [value.strip() for value in values.split(',')]
+    if len(values) != 2:
+        raise InvalidInputParametersError("intensity_range must contain exactly two values.")
+    try:
+        lower, upper = (float(value) for value in values)
+    except (TypeError, ValueError):
+        raise InvalidInputParametersError("intensity_range must contain numeric values.")
+    if not np.isfinite(lower) or np.isnan(upper) or lower > upper:
+        raise InvalidInputParametersError("intensity_range must have a finite lower bound and lower <= upper.")
+    return lower, upper
+
+
+def _as_bool(value) -> bool:
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in ['true', 'yes', '1', 'enable', 'enabled']:
+            return True
+        if text in ['false', 'no', '0', 'disable', 'disabled', '']:
+            return False
+    return bool(value)

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -28,6 +28,27 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class RadiomicsCaseResult:
+    """Per-case result returned by ``BatchRadiomicsExtractor``.
+
+    Attributes
+    ----------
+    case_name : str
+        Name of the case folder.
+    status : {"processed", "skipped", "failed"}
+        Radiomics status for the case. A case is processed when at least one
+        structure produces features.
+    processed_structures : list of str
+        Structure names that produced feature rows.
+    skipped_structures : list of str
+        Structure names that were requested but did not produce feature rows.
+    feature_count : int
+        Number of features extracted across all processed structures for the
+        case.
+    error : str or None, optional
+        Case-level error message. Per-structure extraction failures are usually
+        recorded in ``skipped_structures`` instead.
+    """
+
     case_name: str
     status: str
     processed_structures: list[str] = field(default_factory=list)
@@ -38,7 +59,73 @@ class RadiomicsCaseResult:
 
 @dataclass
 class BatchRadiomicsExtractor:
-    """Extract radiomics features for many case folders and write one CSV."""
+    """Extract radiomics features for many case folders and write one CSV.
+
+    ``BatchRadiomicsExtractor`` is the batch counterpart to
+    ``zrad.radiomics.Radiomics``. It discovers case folders, loads images and
+    masks, prepares ROI data, extracts radiomics features for each requested
+    structure, and writes one CSV file for the whole batch. The API is
+    save-to-disk first; feature rows are written to disk and only summaries are
+    returned in memory.
+
+    Parameters
+    ----------
+    input_directory : str or pathlib.Path
+        Directory containing one subfolder per case.
+    output_directory : str or pathlib.Path
+        Directory where the radiomics CSV is written.
+    input_data_type : {"dicom", "nifti"}
+        Input format. Values are normalized to lower-case during validation.
+    modality : {"CT", "MRI", "PET", "MG", "RTDOSE"}
+        Image modality used by the image reader.
+    aggregation_dimension : {"2D", "2.5D", "3D"}
+        Spatial aggregation dimensionality for texture features.
+    aggregation_method : {"MERG", "AVER", "SLICE_MERG", "DIR_MERG"}
+        Texture aggregation strategy across directions and slices.
+    discretization_method : {"Number of Bins", "Bin Size"}
+        Texture discretization strategy.
+    number_of_threads : int, optional
+        Number of cases to process in parallel. The default is ``1``.
+    patient_folders : sequence of str or str, optional
+        Explicit case folders to process. Comma-separated strings are accepted.
+    start_folder, stop_folder : str or int, optional
+        Inclusive numeric folder range. Both values must be provided together.
+    structures : sequence of str or str, optional
+        Structure names to extract. For NIfTI input these are mask file names
+        and are required.
+    use_all_structures : bool, optional
+        For DICOM input, extract all structures found in the RTSTRUCT.
+    nifti_image_name : str, optional
+        Image file name or stem used for NIfTI input.
+    nifti_filtered_image_name : str, optional
+        Optional filtered-image file name or stem used for NIfTI input.
+    slice_weighting : bool, optional
+        Weight 2D slice-wise texture averages by slice ROI size.
+    slice_median : bool, optional
+        Aggregate 2D slice-wise texture values by median instead of mean.
+    number_of_bins : int, optional
+        Number of bins used with ``"Number of Bins"`` discretization.
+    bin_size : float, optional
+        Bin size used with ``"Bin Size"`` discretization.
+    intensity_range : sequence of float, optional
+        Two-value lower and upper intensity range used for re-segmentation and
+        bin-size discretization.
+    outlier_range : float, optional
+        Positive outlier range used during re-segmentation.
+    output_filename : str, optional
+        CSV file name written in ``output_directory``. The default is
+        ``"radiomics.csv"``.
+    parallel_backend : {"processes", "threads"}, optional
+        Joblib backend preference used when ``number_of_threads`` is greater
+        than one. The default is ``"processes"``.
+
+    Notes
+    -----
+    ``validate()`` normalizes public attributes in place. After validation,
+    directories are ``Path`` objects, ``input_data_type`` is lower-case,
+    modality and aggregation values are upper-case where applicable, and
+    numeric settings are converted to numeric Python values.
+    """
 
     input_directory: str | Path
     output_directory: str | Path
@@ -65,6 +152,15 @@ class BatchRadiomicsExtractor:
     parallel_backend: str = 'processes'
 
     def validate(self) -> None:
+        """Validate and normalize radiomics batch configuration.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If the input directory, data type, modality, folder selection,
+            structure selection, threading, backend, aggregation, or
+            discretization settings are invalid.
+        """
         normalize_common_batch_options(self)
         self.aggregation_dimension = require_text(
             self.aggregation_dimension,
@@ -109,10 +205,47 @@ class BatchRadiomicsExtractor:
         self.outlier_range = _normalize_positive_float(self.outlier_range, "outlier_range must be positive.")
 
     def plan(self) -> list[str]:
+        """Return the case folders selected for radiomics extraction.
+
+        Returns
+        -------
+        folders : list of str
+            Deterministically ordered case folder names selected by
+            ``patient_folders`` or the numeric ``start_folder`` /
+            ``stop_folder`` range. If neither option is set, all non-hidden
+            subfolders are returned.
+
+        Raises
+        ------
+        InvalidInputParametersError
+            If validation fails before folder selection.
+        """
         self.validate()
         return self._resolve_patient_folders()
 
     def run(self, progress_callback: Callable[[int], None] | None = None) -> BatchResult:
+        """Run radiomics extraction and write the output CSV.
+
+        Parameters
+        ----------
+        progress_callback : callable, optional
+            Function called as ``progress_callback(step_count)`` after cases
+            complete. ``step_count`` may be greater than one during parallel
+            execution.
+
+        Returns
+        -------
+        result : BatchResult
+            Aggregate result with one ``RadiomicsCaseResult`` per selected
+            case.
+
+        Notes
+        -----
+        Missing masks and per-structure extraction failures are recorded as
+        skipped structures. Case-level failures are recorded in the returned
+        result and do not stop the batch. If no feature rows are produced, an
+        empty CSV file is still created.
+        """
         self.validate()
         self.output_directory.mkdir(parents=True, exist_ok=True)
         patient_folders = self._resolve_patient_folders()

--- a/zrad/batch/results.py
+++ b/zrad/batch/results.py
@@ -5,8 +5,18 @@ from dataclasses import dataclass
 class BatchResult:
     """Summary returned by batch workflows.
 
-    The individual case-result objects are workflow-specific. They are expected
-    to expose a ``status`` field and may expose an ``error`` field.
+    ``BatchResult`` provides shared aggregate reporting for preprocessing,
+    filtering, and radiomics batch runs. The individual case-result objects are
+    workflow-specific, but they all expose a ``status`` field and may expose an
+    ``error`` field.
+
+    Parameters
+    ----------
+    workflow : str
+        Name of the batch workflow, such as ``"preprocessing"``,
+        ``"filtering"``, or ``"radiomics"``.
+    case_results : list
+        Workflow-specific case-result objects.
     """
 
     workflow: str
@@ -14,20 +24,55 @@ class BatchResult:
 
     @property
     def total_count(self) -> int:
+        """Total number of selected cases.
+
+        Returns
+        -------
+        count : int
+            Number of case results stored in ``case_results``.
+        """
         return len(self.case_results)
 
     @property
     def processed_count(self) -> int:
+        """Number of cases with ``status == "processed"``.
+
+        Returns
+        -------
+        count : int
+            Count of successfully processed case results.
+        """
         return sum(result.status == 'processed' for result in self.case_results)
 
     @property
     def skipped_count(self) -> int:
+        """Number of cases with ``status == "skipped"``.
+
+        Returns
+        -------
+        count : int
+            Count of skipped case results.
+        """
         return sum(result.status == 'skipped' for result in self.case_results)
 
     @property
     def failed_count(self) -> int:
+        """Number of cases with ``status == "failed"``.
+
+        Returns
+        -------
+        count : int
+            Count of failed case results.
+        """
         return sum(result.status == 'failed' for result in self.case_results)
 
     @property
     def errors(self) -> list:
+        """Case results that include an error message.
+
+        Returns
+        -------
+        errors : list
+            Case-result objects where ``error`` is not empty.
+        """
         return [result for result in self.case_results if getattr(result, 'error', None)]

--- a/zrad/batch/results.py
+++ b/zrad/batch/results.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class BatchResult:
+    """Summary returned by batch workflows.
+
+    The individual case-result objects are workflow-specific. They are expected
+    to expose a ``status`` field and may expose an ``error`` field.
+    """
+
+    workflow: str
+    case_results: list
+
+    @property
+    def total_count(self) -> int:
+        return len(self.case_results)
+
+    @property
+    def processed_count(self) -> int:
+        return sum(result.status == 'processed' for result in self.case_results)
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(result.status == 'skipped' for result in self.case_results)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(result.status == 'failed' for result in self.case_results)
+
+    @property
+    def errors(self) -> list:
+        return [result for result in self.case_results if getattr(result, 'error', None)]

--- a/zrad/gui/filt_tab.py
+++ b/zrad/gui/filt_tab.py
@@ -4,13 +4,12 @@ import os
 import sys
 from datetime import datetime
 
-from joblib import Parallel, delayed
 from PyQt5.QtCore import QThread
 
-from ..exceptions import DataStructureError, InvalidInputParametersError
-from ..filtering import create_filter
-from ..toolbox_logic import close_all_loggers, get_logger, joblib_progress
-from ._base_tab import BaseTab, load_images
+from ..batch import BatchFilter
+from ..exceptions import InvalidInputParametersError
+from ..toolbox_logic import close_all_loggers, get_logger
+from ._base_tab import BaseTab
 from .toolbox_gui import (
     CustomBox,
     CustomButton,
@@ -28,146 +27,46 @@ logging.captureWarnings(True)
 IS_FROZEN = getattr(sys, 'frozen', False)
 
 
-def _get_filtering(input_params):
-    if input_params["filter_type"] == 'Mean':
-        filtering = create_filter(
-            filtering_method=input_params["filter_type"],
-            padding_type=input_params["filter_padding_type"],
-            support=int(input_params["filter_mean_support"]),
-            dimensionality=input_params["filter_dimension"],
-        )
-
-    elif input_params["filter_type"] == 'Laplacian of Gaussian':
-        filtering = create_filter(
-            filtering_method=input_params["filter_type"],
-            padding_type=input_params["filter_padding_type"],
-            sigma_mm=float(input_params["filter_log_sigma"]),
-            cutoff=float(input_params["filter_log_cutoff"]),
-            dimensionality=input_params["filter_dimension"],
-        )
-    elif input_params["filter_type"] == 'Laws Kernels':
-        filtering = create_filter(
-            filtering_method=input_params["filter_type"],
-            response_map=input_params["filter_laws_response_map"],
-            padding_type=input_params["filter_padding_type"],
-            dimensionality=input_params["filter_dimension"],
-            rotation_invariance=input_params["filter_laws_rot_inv"] == 'Enable',
-            pooling=input_params["filter_laws_pooling"],
-            energy_map=input_params["filter_laws_energy_map"] == 'Enable',
-            distance=int(input_params["filter_laws_distance"]),
-        )
-    elif input_params["filter_type"] == 'Gabor':
-        filtering = create_filter(
-            filtering_method='Gabor',
-            padding_type=input_params["filter_padding_type"],
-            res_mm=float(input_params["filter_gabor_res_mm"]),
-            sigma_mm=float(input_params["filter_gabor_sigma_mm"]),
-            lambda_mm=float(input_params["filter_gabor_lambda_mm"]),
-            gamma=float(input_params["filter_gabor_gamma"]),
-            theta=float(input_params["filter_gabor_theta"]),
-            rotation_invariance=input_params["filter_gabor_rotinv"] == 'Enable',
-            orthogonal_planes=input_params["filter_gabor_ortho"] == 'Enable',
-        )
-    elif input_params["filter_type"] == 'Wavelets':
-        if input_params["filter_dimension"] == '2D':
-            filtering = create_filter(
-                filtering_method=input_params["filter_type"],
-                dimensionality=input_params["filter_dimension"],
-                padding_type=input_params["filter_padding_type"],
-                wavelet_type=input_params["filter_wavelet_type"],
-                response_map=input_params["filter_wavelet_resp_map_2D"],
-                decomposition_level=int(input_params["filter_wavelet_decomp_lvl"]),
-                rotation_invariance=input_params["filter_wavelet_rot_inv"] == 'Enable',
-            )
-        elif input_params["filter_dimension"] == '3D':
-            filtering = create_filter(
-                filtering_method=input_params["filter_type"],
-                dimensionality=input_params["filter_dimension"],
-                padding_type=input_params["filter_padding_type"],
-                wavelet_type=input_params["filter_wavelet_type"],
-                response_map=input_params["filter_wavelet_resp_map_3D"],
-                decomposition_level=int(input_params["filter_wavelet_decomp_lvl"]),
-                rotation_invariance=input_params["filter_wavelet_rot_inv"] == 'Enable',
-            )
-        else:
-            raise InvalidInputParametersError(f"Filter_dimension {input_params['filter_dimension']} is not supported.")
-    else:
-        raise InvalidInputParametersError(f"Filter_type {input_params['filter_type']} not supported.")
-
-    return filtering
-
-
-def _get_filename(input_params):
-    # Base formats for all filters except Wavelets
-    filter_formats = {
-        'Mean': "{filter_type}_{filter_dimension}_{filter_mean_support}support_{filter_padding_type}",
-        'Laplacian of Gaussian': "{filter_type}_{filter_dimension}_{filter_log_sigma}sigma_"
-        "{filter_log_cutoff}cutoff_{filter_padding_type}",
-        'Laws Kernels': "{filter_type}_{filter_dimension}_{filter_laws_response_map}_"
-        "{filter_laws_rot_inv}_{filter_laws_pooling}_"
-        "{filter_laws_energy_map}_{filter_laws_distance}_{filter_padding_type}",
-        'Gabor': "Gabor_{filter_dimension}_"
-        "{filter_gabor_res_mm}resmm_"
-        "{filter_gabor_sigma_mm}sigmm_"
-        "{filter_gabor_lambda_mm}lambmm_"
-        "g{filter_gabor_gamma}_"
-        "t{filter_gabor_theta}_"
-        "{filter_gabor_rotinv}_"
-        "{filter_gabor_ortho}_"
-        "{filter_padding_type}",
-    }
-
-    def format_wavelets():
-        base = (
-            "{filter_wavelet_type}_{filter_dimension}_"
-            "{filter_wavelet_resp_map}_"
-            "{filter_wavelet_decomp_lvl}_"
-            "{filter_wavelet_rot_inv}_"
-            "{filter_padding_type}"
-        )
-        resp = (
-            input_params["filter_wavelet_resp_map_3D"]
-            if input_params["filter_dimension"] == '3D'
-            else input_params["filter_wavelet_resp_map_2D"]
-        )
-        return base.format(filter_wavelet_resp_map=resp, **input_params)
-
-    ft = input_params["filter_type"]
-    if ft == 'Wavelets':
-        filename = format_wavelets()
-    elif ft in filter_formats:
-        filename = filter_formats[ft].format(**input_params)
-    else:
-        raise InvalidInputParametersError(f"Unknown filter type: {ft}")
-
-    return f"{filename}.nii.gz"
-
-
-def process_patient_folder(input_params, patient_folder):
-
-    local_params = dict(input_params)
-
-    # Logger
-    logger_date_time = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    logger = get_logger(logger_date_time + '_Filtering')
-
-    # Initialize Filtering instance
-    filtering = _get_filtering(local_params)
-
-    logger.info(f"Filtering patient's {patient_folder} image.")
-
-    try:
-        image = load_images(local_params, patient_folder)
-    except DataStructureError as e:
-        logger.error(e)
-        logger.error(f"Patient {patient_folder} could not be loaded and is skipped.")
-        return
-    image_new = filtering.apply(image)
-
-    # Save new image
-    filename = _get_filename(local_params)
-    output_path = os.path.join(local_params["output_directory"], patient_folder, filename)
-    image_new.save_as_nifti(output_path)
+def create_batch_filter_from_input_params(input_params, parallel_backend):
+    response_map = (
+        input_params["filter_wavelet_resp_map_3D"]
+        if input_params["filter_dimension"] == '3D'
+        else input_params["filter_wavelet_resp_map_2D"]
+    )
+    return BatchFilter(
+        input_directory=input_params["input_directory"],
+        output_directory=input_params["output_directory"],
+        input_data_type=input_params["input_data_type"],
+        modality=input_params["input_image_modality"],
+        number_of_threads=input_params["number_of_threads"],
+        patient_folders=input_params["list_of_patient_folders"],
+        start_folder=input_params["start_folder"],
+        stop_folder=input_params["stop_folder"],
+        nifti_image_name=input_params["nifti_image_name"],
+        filter_type=input_params["filter_type"],
+        filter_dimension=input_params["filter_dimension"],
+        padding_type=input_params["filter_padding_type"],
+        mean_support=input_params["filter_mean_support"],
+        log_sigma=input_params["filter_log_sigma"],
+        log_cutoff=input_params["filter_log_cutoff"],
+        laws_response_map=input_params["filter_laws_response_map"],
+        laws_rotation_invariance=input_params["filter_laws_rot_inv"],
+        laws_pooling=input_params["filter_laws_pooling"],
+        laws_energy_map=input_params["filter_laws_energy_map"],
+        laws_distance=input_params["filter_laws_distance"],
+        wavelet_response_map=response_map,
+        wavelet_type=input_params["filter_wavelet_type"],
+        wavelet_decomposition_level=input_params["filter_wavelet_decomp_lvl"],
+        wavelet_rotation_invariance=input_params["filter_wavelet_rot_inv"],
+        gabor_res_mm=input_params["filter_gabor_res_mm"],
+        gabor_sigma_mm=input_params["filter_gabor_sigma_mm"],
+        gabor_lambda_mm=input_params["filter_gabor_lambda_mm"],
+        gabor_gamma=input_params["filter_gabor_gamma"],
+        gabor_theta=input_params["filter_gabor_theta"],
+        gabor_rotation_invariance=input_params["filter_gabor_rotinv"],
+        gabor_orthogonal_planes=input_params["filter_gabor_ortho"],
+        parallel_backend=parallel_backend,
+    )
 
 
 class FilteringTab(BaseTab):
@@ -506,32 +405,27 @@ class FilteringTab(BaseTab):
             CustomWarningBox(str(e)).response()
             return
 
-        # Get patient folders
-        list_of_patient_folders = self.get_patient_folders()
-
-        # Process each patient folder
         if IS_FROZEN:
             backend_hint = "threads"
             self.logger.info("Frozen state. Set backend_hint to threads")
         else:
             backend_hint = "processes"
             self.logger.info("Not frozen state. Set backend_hint to processes")
+
+        batch_filter = create_batch_filter_from_input_params(self.input_params, backend_hint)
+        try:
+            list_of_patient_folders = batch_filter.plan()
+        except InvalidInputParametersError as e:
+            self.logger.error(e)
+            CustomWarningBox(str(e)).response()
+            return
+
         if list_of_patient_folders:
             progress_dialog = ProcessingProgressDialog("Filtering Progress", len(list_of_patient_folders), self)
             progress_dialog.start()
-            n_jobs = self.input_params["number_of_threads"]
 
             def work(progress_callback):
-                if n_jobs == 1:
-                    for patient_folder in list_of_patient_folders:
-                        process_patient_folder(self.input_params, patient_folder)
-                        progress_callback(1)
-                else:
-                    with joblib_progress(progress_callback=progress_callback):
-                        Parallel(n_jobs=n_jobs, prefer=backend_hint)(
-                            delayed(process_patient_folder)(self.input_params, patient_folder)
-                            for patient_folder in list_of_patient_folders
-                        )
+                return batch_filter.run(progress_callback=progress_callback)
 
             worker = ProcessingWorker(work)
             thread = QThread(self)
@@ -545,7 +439,14 @@ class FilteringTab(BaseTab):
 
             def handle_finished(_result):
                 cleanup()
-                self.logger.info("Filtering finished!")
+                self.logger.info(
+                    "Filtering finished! Processed: %s, skipped: %s, failed: %s",
+                    _result.processed_count,
+                    _result.skipped_count,
+                    _result.failed_count,
+                )
+                for case_result in _result.errors:
+                    self.logger.error("%s: %s", case_result.case_name, case_result.error)
                 CustomInfoBox("Filtering finished!").response()
 
             def handle_error(exc):

--- a/zrad/gui/prep_tab.py
+++ b/zrad/gui/prep_tab.py
@@ -4,15 +4,12 @@ import os
 import sys
 from datetime import datetime
 
-import numpy as np
-from joblib import Parallel, delayed
 from PyQt5.QtCore import QThread
 
-from ..exceptions import DataStructureError, InvalidInputParametersError
-from ..io.dicom import get_all_structure_names, get_dicom_files
-from ..preprocessing import ImageResampler, MaskResampler
-from ..toolbox_logic import close_all_loggers, get_logger, joblib_progress
-from ._base_tab import BaseTab, load_images, load_mask
+from ..batch import BatchPreprocessor
+from ..exceptions import InvalidInputParametersError
+from ..toolbox_logic import close_all_loggers, get_logger
+from ._base_tab import BaseTab
 from .toolbox_gui import (
     CustomBox,
     CustomCheckBox,
@@ -28,95 +25,6 @@ from .toolbox_gui import (
 logging.captureWarnings(True)
 
 IS_FROZEN = getattr(sys, 'frozen', False)
-
-
-def _target_resolution(image, resolution, dimension):
-    if dimension == '3D':
-        return (resolution, resolution, resolution)
-    if dimension == '2D':
-        return (resolution, resolution, image.spacing[2])
-    raise ValueError(f"Resample dimension '{dimension}' is not supported.")
-
-
-def process_patient_folder(input_params, patient_folder, structure_set):
-
-    local_params = dict(input_params)
-
-    """Function to process each patient folder, used for parallel processing."""
-    # Logger
-    logger_date_time = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    logger = get_logger(logger_date_time + '_Preprocessing')
-    logger.info(f"Processing patient's {patient_folder} image.")
-    try:
-        image = load_images(local_params, patient_folder)
-    except (DataStructureError, ValueError) as e:
-        logger.error(e)
-        logger.error(f"Patient {patient_folder} could not be loaded and is skipped.")
-        return
-
-    if local_params["just_save_as_nifti"]:
-        image_new = image.copy()
-    else:
-        prep_image = ImageResampler(
-            resolution=_target_resolution(
-                image,
-                local_params["resample_resolution"],
-                local_params["resample_dimension"],
-            ),
-            method=local_params["image_interpolation_method"],
-            intensity_rounding=("nearest_integer" if local_params["input_imaging_modality"] == "CT" else None),
-        )
-        image_new = prep_image.apply(image)
-
-    # Save new image
-    output_path = os.path.join(local_params["output_directory"], patient_folder, 'image.nii.gz')
-    image_new.save_as_nifti(output_path)
-
-    # Process masks
-    if local_params["input_data_type"] == 'dicom':
-        input_directory = os.path.join(local_params["input_directory"], patient_folder)
-        rtstruct_paths = get_dicom_files(input_directory, modality='RTSTRUCT')
-
-        if rtstruct_paths:
-            local_params['rtstruct_path'] = rtstruct_paths[0]['file_path']
-            if local_params["use_all_structures"]:
-                structure_set = get_all_structure_names(local_params['rtstruct_path'])
-        else:
-            local_params['rtstruct_path'] = None
-
-    if structure_set:
-        mask_union = None
-        for mask_name in structure_set:
-            mask = load_mask(local_params, patient_folder, mask_name, image)
-            if mask and mask.array is not None:
-                logger.info(f"Processing patient's {patient_folder} ROI: {mask_name}.")
-                if local_params["just_save_as_nifti"]:
-                    mask_new = mask.copy()
-                else:
-                    prep_mask = MaskResampler(
-                        resolution=_target_resolution(
-                            mask,
-                            local_params["resample_resolution"],
-                            local_params["resample_dimension"],
-                        ),
-                        method=local_params["mask_interpolation_method"],
-                        partial_volume_threshold=local_params["mask_interpolation_threshold"],
-                    )
-                    mask_new = prep_mask.apply(mask)
-
-                # Save new mask
-                output_path = os.path.join(local_params["output_directory"], patient_folder, f'{mask_name}.nii.gz')
-                mask_new.save_as_nifti(output_path)
-
-                if local_params["mask_union"]:
-                    if mask_union:
-                        mask_union.array = np.bitwise_or(mask_union.array, mask_new.array).astype(np.int16)
-                    else:
-                        mask_union = mask_new.copy()
-
-        if mask_union:
-            output_path = os.path.join(local_params["output_directory"], patient_folder, 'mask_union.nii.gz')
-            mask_union.save_as_nifti(output_path)
 
 
 class PreprocessingTab(BaseTab):
@@ -388,6 +296,34 @@ class PreprocessingTab(BaseTab):
         }
         self.input_params = input_parameters
 
+    def _create_batch_preprocessor(self, parallel_backend):
+        if self.input_params["input_data_type"] == "nifti":
+            structures = self.input_params.get("nifti_structures")
+        else:
+            structures = None if self.input_params["use_all_structures"] else self.input_params["dicom_structures"]
+
+        return BatchPreprocessor(
+            input_directory=self.input_params["input_directory"],
+            output_directory=self.input_params["output_directory"],
+            input_data_type=self.input_params["input_data_type"],
+            modality=self.input_params["input_imaging_modality"],
+            number_of_threads=self.input_params["number_of_threads"],
+            patient_folders=self.input_params["list_of_patient_folders"],
+            start_folder=self.input_params["start_folder"],
+            stop_folder=self.input_params["stop_folder"],
+            structures=structures,
+            use_all_structures=bool(self.input_params["use_all_structures"]),
+            nifti_image_name=self.input_params["nifti_image_name"],
+            just_save_as_nifti=bool(self.input_params["just_save_as_nifti"]),
+            resample_resolution=self.input_params["resample_resolution"],
+            resample_dimension=self.input_params["resample_dimension"],
+            image_interpolation_method=self.input_params["image_interpolation_method"],
+            mask_interpolation_method=self.input_params["mask_interpolation_method"],
+            mask_interpolation_threshold=self.input_params["mask_interpolation_threshold"],
+            mask_union=bool(self.input_params["mask_union"]),
+            parallel_backend=parallel_backend,
+        )
+
     def run_selection(self):
         """Executes preprocessing based on user-selected options."""
         close_all_loggers()
@@ -407,40 +343,27 @@ class PreprocessingTab(BaseTab):
             CustomWarningBox(str(e)).response()
             return
 
-        # Get patient folders
-        list_of_patient_folders = self.get_patient_folders()
-
-        # Determine structure set based on data type
-        structure_set = None
-        if self.input_params["input_data_type"].lower() == "nifti":
-            structure_set = self.input_params.get("nifti_structures")
-        elif self.input_params["input_data_type"].lower() == "dicom":
-            if not self.input_params["use_all_structures"]:
-                structure_set = self.input_params["dicom_structures"]
-
-        # Process each patient folder
         if IS_FROZEN:
             backend_hint = "threads"
             self.logger.info("Frozen state. Set backend_hint to threads")
         else:
             backend_hint = "processes"
             self.logger.info("Not frozen state. Set backend_hint to processes")
+
+        batch_preprocessor = self._create_batch_preprocessor(backend_hint)
+        try:
+            list_of_patient_folders = batch_preprocessor.plan()
+        except InvalidInputParametersError as e:
+            self.logger.error(e)
+            CustomWarningBox(str(e)).response()
+            return
+
         if list_of_patient_folders:
             progress_dialog = ProcessingProgressDialog("Preprocessing Progress", len(list_of_patient_folders), self)
             progress_dialog.start()
-            n_jobs = self.input_params["number_of_threads"]
 
             def work(progress_callback):
-                if n_jobs == 1:
-                    for patient_folder in list_of_patient_folders:
-                        process_patient_folder(self.input_params, patient_folder, structure_set)
-                        progress_callback(1)
-                else:
-                    with joblib_progress(progress_callback=progress_callback):
-                        Parallel(n_jobs=n_jobs, prefer=backend_hint)(
-                            delayed(process_patient_folder)(self.input_params, patient_folder, structure_set)
-                            for patient_folder in list_of_patient_folders
-                        )
+                return batch_preprocessor.run(progress_callback=progress_callback)
 
             worker = ProcessingWorker(work)
             thread = QThread(self)
@@ -454,7 +377,14 @@ class PreprocessingTab(BaseTab):
 
             def handle_finished(_result):
                 cleanup()
-                self.logger.info("Preprocessing finished!")
+                self.logger.info(
+                    "Preprocessing finished! Processed: %s, skipped: %s, failed: %s",
+                    _result.processed_count,
+                    _result.skipped_count,
+                    _result.failed_count,
+                )
+                for case_result in _result.errors:
+                    self.logger.error("%s: %s", case_result.case_name, case_result.error)
                 CustomInfoBox("Preprocessing finished!").response()
 
             def handle_error(exc):

--- a/zrad/gui/prep_tab.py
+++ b/zrad/gui/prep_tab.py
@@ -29,10 +29,11 @@ IS_FROZEN = getattr(sys, 'frozen', False)
 
 def create_batch_preprocessor_from_input_params(input_params, parallel_backend):
     input_data_type = str(input_params["input_data_type"]).strip().lower()
+    use_all_structures = input_data_type == "dicom" and bool(input_params["use_all_structures"])
     if input_data_type == "nifti":
         structures = input_params.get("nifti_structures")
     else:
-        structures = None if input_params["use_all_structures"] else input_params["dicom_structures"]
+        structures = None if use_all_structures else input_params["dicom_structures"]
 
     return BatchPreprocessor(
         input_directory=input_params["input_directory"],
@@ -44,7 +45,7 @@ def create_batch_preprocessor_from_input_params(input_params, parallel_backend):
         start_folder=input_params["start_folder"],
         stop_folder=input_params["stop_folder"],
         structures=structures,
-        use_all_structures=bool(input_params["use_all_structures"]),
+        use_all_structures=use_all_structures,
         nifti_image_name=input_params["nifti_image_name"],
         just_save_as_nifti=bool(input_params["just_save_as_nifti"]),
         resample_resolution=input_params["resample_resolution"],

--- a/zrad/gui/prep_tab.py
+++ b/zrad/gui/prep_tab.py
@@ -27,6 +27,36 @@ logging.captureWarnings(True)
 IS_FROZEN = getattr(sys, 'frozen', False)
 
 
+def create_batch_preprocessor_from_input_params(input_params, parallel_backend):
+    input_data_type = str(input_params["input_data_type"]).strip().lower()
+    if input_data_type == "nifti":
+        structures = input_params.get("nifti_structures")
+    else:
+        structures = None if input_params["use_all_structures"] else input_params["dicom_structures"]
+
+    return BatchPreprocessor(
+        input_directory=input_params["input_directory"],
+        output_directory=input_params["output_directory"],
+        input_data_type=input_params["input_data_type"],
+        modality=input_params["input_imaging_modality"],
+        number_of_threads=input_params["number_of_threads"],
+        patient_folders=input_params["list_of_patient_folders"],
+        start_folder=input_params["start_folder"],
+        stop_folder=input_params["stop_folder"],
+        structures=structures,
+        use_all_structures=bool(input_params["use_all_structures"]),
+        nifti_image_name=input_params["nifti_image_name"],
+        just_save_as_nifti=bool(input_params["just_save_as_nifti"]),
+        resample_resolution=input_params["resample_resolution"],
+        resample_dimension=input_params["resample_dimension"],
+        image_interpolation_method=input_params["image_interpolation_method"],
+        mask_interpolation_method=input_params["mask_interpolation_method"],
+        mask_interpolation_threshold=input_params["mask_interpolation_threshold"],
+        mask_union=bool(input_params["mask_union"]),
+        parallel_backend=parallel_backend,
+    )
+
+
 class PreprocessingTab(BaseTab):
     def __init__(self):
         super().__init__()
@@ -297,32 +327,7 @@ class PreprocessingTab(BaseTab):
         self.input_params = input_parameters
 
     def _create_batch_preprocessor(self, parallel_backend):
-        if self.input_params["input_data_type"] == "nifti":
-            structures = self.input_params.get("nifti_structures")
-        else:
-            structures = None if self.input_params["use_all_structures"] else self.input_params["dicom_structures"]
-
-        return BatchPreprocessor(
-            input_directory=self.input_params["input_directory"],
-            output_directory=self.input_params["output_directory"],
-            input_data_type=self.input_params["input_data_type"],
-            modality=self.input_params["input_imaging_modality"],
-            number_of_threads=self.input_params["number_of_threads"],
-            patient_folders=self.input_params["list_of_patient_folders"],
-            start_folder=self.input_params["start_folder"],
-            stop_folder=self.input_params["stop_folder"],
-            structures=structures,
-            use_all_structures=bool(self.input_params["use_all_structures"]),
-            nifti_image_name=self.input_params["nifti_image_name"],
-            just_save_as_nifti=bool(self.input_params["just_save_as_nifti"]),
-            resample_resolution=self.input_params["resample_resolution"],
-            resample_dimension=self.input_params["resample_dimension"],
-            image_interpolation_method=self.input_params["image_interpolation_method"],
-            mask_interpolation_method=self.input_params["mask_interpolation_method"],
-            mask_interpolation_threshold=self.input_params["mask_interpolation_threshold"],
-            mask_union=bool(self.input_params["mask_union"]),
-            parallel_backend=parallel_backend,
-        )
+        return create_batch_preprocessor_from_input_params(self.input_params, parallel_backend)
 
     def run_selection(self):
         """Executes preprocessing based on user-selected options."""

--- a/zrad/gui/rad_tab.py
+++ b/zrad/gui/rad_tab.py
@@ -30,8 +30,9 @@ IS_FROZEN = getattr(sys, 'frozen', False)
 
 def create_batch_radiomics_extractor_from_input_params(input_params, parallel_backend):
     input_data_type = str(input_params["input_data_type"]).strip().lower()
+    use_all_structures = input_data_type == "dicom" and bool(input_params["use_all_structures"])
     structures = input_params["nifti_structures"] if input_data_type == "nifti" else input_params["dicom_structures"]
-    if input_data_type == "dicom" and input_params["use_all_structures"]:
+    if use_all_structures:
         structures = None
 
     aggregation_dimension, aggregation_method = input_params["aggregation_method"]
@@ -48,7 +49,7 @@ def create_batch_radiomics_extractor_from_input_params(input_params, parallel_ba
         start_folder=input_params["start_folder"],
         stop_folder=input_params["stop_folder"],
         structures=structures,
-        use_all_structures=bool(input_params["use_all_structures"]),
+        use_all_structures=use_all_structures,
         nifti_image_name=input_params["nifti_image_name"],
         nifti_filtered_image_name=input_params["nifti_filtered_image_name"],
         aggregation_dimension=aggregation_dimension,

--- a/zrad/gui/rad_tab.py
+++ b/zrad/gui/rad_tab.py
@@ -1,4 +1,3 @@
-import csv
 import json
 import logging
 import os
@@ -6,15 +5,12 @@ import sys
 from datetime import datetime
 
 import numpy as np
-from joblib import Parallel, delayed
 from PyQt5.QtCore import QThread
 
-from ..exceptions import DataStructureError, InvalidInputParametersError
-from ..io.dicom import get_all_structure_names, get_dicom_files
-from ..preprocessing import IntensityMaskBuilder, Resegmenter, RoiData, TextureDiscretizer
-from ..radiomics import Radiomics
-from ..toolbox_logic import close_all_loggers, get_logger, joblib_progress
-from ._base_tab import BaseTab, load_images, load_mask
+from ..batch import BatchRadiomicsExtractor
+from ..exceptions import InvalidInputParametersError
+from ..toolbox_logic import close_all_loggers, get_logger
+from ._base_tab import BaseTab
 from .toolbox_gui import (
     CustomBox,
     CustomCheckBox,
@@ -32,108 +28,40 @@ logging.captureWarnings(True)
 IS_FROZEN = getattr(sys, 'frozen', False)
 
 
-def process_patient_folder(input_params, patient_folder, structure_set):
+def create_batch_radiomics_extractor_from_input_params(input_params, parallel_backend):
+    input_data_type = str(input_params["input_data_type"]).strip().lower()
+    structures = input_params["nifti_structures"] if input_data_type == "nifti" else input_params["dicom_structures"]
+    if input_data_type == "dicom" and input_params["use_all_structures"]:
+        structures = None
 
-    local_params = dict(input_params)
+    aggregation_dimension, aggregation_method = input_params["aggregation_method"]
+    slice_weighting = aggregation_dimension == '2D' and input_params["weighting"] == 'Weighted Mean'
+    slice_median = aggregation_dimension == '2D' and input_params["weighting"] == 'Median'
 
-    # Logger
-    logger_date_time = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    logger = get_logger(logger_date_time + '_Radiomics')
-
-    def is_slice_weighting():
-        """Determines if slice weighting is applied based on current settings."""
-        aggr_dim = local_params["agr_strategy"].split(',')[0]
-        weighting = local_params["weighting"]
-        if aggr_dim == '2D':
-            return weighting == 'Weighted Mean'
-        return False
-
-    def is_slice_median():
-        """Determines if slice median is applied based on current settings."""
-        aggr_dim = local_params["agr_strategy"].split(',')[0]
-        weighting = local_params["weighting"]
-        if aggr_dim == '2D':
-            return weighting == 'Median'
-        return False
-
-    # Initialize Radiomics instance
-    rad_instance = Radiomics(
-        aggr_dim=local_params['aggregation_method'][0],
-        aggr_method=local_params['aggregation_method'][1],
-        slice_weighting=is_slice_weighting(),
-        slice_median=is_slice_median(),
+    return BatchRadiomicsExtractor(
+        input_directory=input_params["input_directory"],
+        output_directory=input_params["output_directory"],
+        input_data_type=input_params["input_data_type"],
+        modality=input_params["input_imaging_modality"],
+        number_of_threads=input_params["number_of_threads"],
+        patient_folders=input_params["list_of_patient_folders"],
+        start_folder=input_params["start_folder"],
+        stop_folder=input_params["stop_folder"],
+        structures=structures,
+        use_all_structures=bool(input_params["use_all_structures"]),
+        nifti_image_name=input_params["nifti_image_name"],
+        nifti_filtered_image_name=input_params["nifti_filtered_image_name"],
+        aggregation_dimension=aggregation_dimension,
+        aggregation_method=aggregation_method,
+        slice_weighting=slice_weighting,
+        slice_median=slice_median,
+        discretization_method=input_params["discretization"][0],
+        number_of_bins=input_params["discretization"][1],
+        bin_size=input_params["discretization"][2],
+        intensity_range=input_params["intensity_range"],
+        outlier_range=input_params["outlier_range"],
+        parallel_backend=parallel_backend,
     )
-
-    logger.info(f"Processing patient: {patient_folder}.")
-    try:
-        if local_params["nifti_filtered_image_name"]:
-            image, filtered_image = load_images(local_params, patient_folder)
-        else:
-            image = load_images(local_params, patient_folder)
-            filtered_image = None
-    except DataStructureError as e:
-        logger.error(e)
-
-    if local_params["input_data_type"] == 'dicom':
-        input_directory = os.path.join(local_params["input_directory"], patient_folder)
-        local_params['rtstruct_path'] = get_dicom_files(input_directory, modality='RTSTRUCT')[0]['file_path']
-        if local_params["use_all_structures"]:
-            structure_set = get_all_structure_names(local_params['rtstruct_path'])
-
-    radiomic_features_list = []
-    for mask_name in structure_set:
-        mask = load_mask(local_params, patient_folder, mask_name, image)
-        if mask and mask.array is not None:
-            logger.info(f"Processing patient: {patient_folder} with ROI: {mask_name}.")
-            try:
-                roi_data = IntensityMaskBuilder().apply(
-                    RoiData(
-                        image=image,
-                        filtered_image=filtered_image,
-                        morphological_mask=mask,
-                    )
-                )
-                roi_data = Resegmenter(
-                    intensity_range=local_params['intensity_range'],
-                    outlier_range=local_params['outlier_range'],
-                ).apply(roi_data)
-                roi_data = TextureDiscretizer(
-                    number_of_bins=local_params['discretization'][1],
-                    bin_size=local_params['discretization'][2],
-                ).apply(roi_data)
-                radiomic_features = rad_instance.extract_features(
-                    roi_data=roi_data,
-                    include_metadata=True,
-                )
-            except (DataStructureError, ValueError) as e:
-                logger.error(e)
-                logger.info(f"Patient {patient_folder} with mask {mask_name} skipped.")
-                continue
-            radiomic_features['pat_id'] = patient_folder
-            radiomic_features['mask_id'] = mask_name
-            radiomic_features_list.append(radiomic_features)
-
-    return radiomic_features_list
-
-
-def _write_radiomics_csv(file_path, features):
-    if not features:
-        return
-
-    fieldnames = []
-    for key in ("pat_id", "mask_id", "bounding_box_min", "no_voxels", "no_bins"):
-        if any(key in row for row in features):
-            fieldnames.append(key)
-
-    for row in features:
-        for key in row.keys():
-            if key not in fieldnames:
-                fieldnames.append(key)
-
-    with open(file_path, "w", newline="") as csv_file:
-        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(features)
 
 
 class RadiomicsTab(BaseTab):
@@ -350,45 +278,27 @@ class RadiomicsTab(BaseTab):
             CustomWarningBox(str(e)).response()
             return
 
-        # Get patient folders
-        list_of_patient_folders = self.get_patient_folders()
-
-        # Determine structure set based on data type
-        structure_set = None
-        if self.input_params["input_data_type"] == "nifti":
-            structure_set = self.input_params.get("nifti_structures")
-        elif self.input_params["input_data_type"] == "dicom":
-            if not self.input_params["use_all_structures"]:
-                structure_set = self.input_params["dicom_structures"]
-
-        # Process each patient folder
         if IS_FROZEN:
             backend_hint = "threads"
             self.logger.info("Frozen state. Set backend_hint to threads")
         else:
             backend_hint = "processes"
             self.logger.info("Not frozen state. Set backend_hint to processes")
+
+        batch_extractor = create_batch_radiomics_extractor_from_input_params(self.input_params, backend_hint)
+        try:
+            list_of_patient_folders = batch_extractor.plan()
+        except InvalidInputParametersError as e:
+            self.logger.error(e)
+            CustomWarningBox(str(e)).response()
+            return
+
         if list_of_patient_folders:
             progress_dialog = ProcessingProgressDialog("Radiomics Progress", len(list_of_patient_folders), self)
             progress_dialog.start()
-            n_jobs = self.input_params["number_of_threads"]
 
             def work(progress_callback):
-                if n_jobs == 1:
-                    radiomic_features = []
-                    for patient_folder in list_of_patient_folders:
-                        radiomic_features.append(
-                            process_patient_folder(self.input_params, patient_folder, structure_set)
-                        )
-                        progress_callback(1)
-                else:
-                    with joblib_progress(progress_callback=progress_callback):
-                        radiomic_features = Parallel(n_jobs=n_jobs, prefer=backend_hint)(
-                            delayed(process_patient_folder)(self.input_params, patient_folder, structure_set)
-                            for patient_folder in list_of_patient_folders
-                        )
-
-                return radiomic_features
+                return batch_extractor.run(progress_callback=progress_callback)
 
             worker = ProcessingWorker(work)
             thread = QThread(self)
@@ -400,13 +310,18 @@ class RadiomicsTab(BaseTab):
                 worker.deleteLater()
                 thread.deleteLater()
 
-            def handle_finished(radiomic_features_list):
+            def handle_finished(result):
                 cleanup()
-                if radiomic_features_list:
-                    radiomic_features_list = [item for sublist in radiomic_features_list for item in sublist]
-                    file_path = os.path.join(self.input_params["output_directory"], 'radiomics.csv')
-                    _write_radiomics_csv(file_path, radiomic_features_list)
-                    self.logger.info(f"Radiomics saved to {file_path}.")
+                file_path = os.path.join(self.input_params["output_directory"], 'radiomics.csv')
+                self.logger.info(
+                    "Radiomics finished with %s processed, %s skipped, and %s failed cases.",
+                    result.processed_count,
+                    result.skipped_count,
+                    result.failed_count,
+                )
+                for case_result in result.errors:
+                    self.logger.error("Patient %s: %s", case_result.case_name, case_result.error)
+                self.logger.info(f"Radiomics saved to {file_path}.")
                 self.logger.info("Radiomics finished!")
                 CustomInfoBox("Radiomics finished!").response()
 


### PR DESCRIPTION
This PR adds a new `zrad.batch` API for running cohort-level workflows using API and updates the GUI to use the same batch logic.

Main changes:
- Added `BatchPreprocessor`, `BatchFilter`, and `BatchRadiomicsExtractor`
- Added shared `BatchResult` reporting
- Moved preprocessing, filtering, and radiomics batch orchestration out of the GUI
- Added tests for validation, folder selection, progress, errors, and outputs
- Updated docs with batch API examples

The GUI behavior should stay the same, but the batch logic is now reusable from the API.