### PR TITLE
FIX Meshes for Open Masks

### DIFF
--- a/tests/test_radiomics.py
+++ b/tests/test_radiomics.py
@@ -11,6 +11,7 @@ from zrad.preprocessing import (
     TextureDiscretizer,
 )
 from zrad.radiomics import Radiomics
+from zrad.radiomics.morphology import MorphologicalFeatures
 
 
 def _make_image(array):
@@ -45,6 +46,19 @@ def test_radiomics_extract_features_returns_dict_from_roi_data():
 
     assert isinstance(features, dict)
     assert set(features) == {'loc_peak_loc', 'loc_peak_glob'}
+
+
+@pytest.mark.unit
+def test_morphology_mesh_handles_roi_touching_image_border():
+    mask_array = np.ones((3, 3, 3), dtype=np.float64)
+
+    mesh_verts, mesh_faces = MorphologicalFeatures(spacing=(1.0, 1.0, 1.0))._calc_mesh(mask_array)
+
+    assert mesh_verts.shape[1] == 3
+    assert mesh_faces.shape[1] == 3
+    assert mesh_faces.size > 0
+    assert np.min(mesh_verts) == pytest.approx(-0.5)
+    assert np.max(mesh_verts) == pytest.approx(2.5)
 
 
 @pytest.mark.unit

--- a/zrad/__init__.py
+++ b/zrad/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "26.6.0.dev"
+__version__ = "26.6.0.dev0"

--- a/zrad/__init__.py
+++ b/zrad/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "26.5.1.dev0"
+__version__ = "26.6.0.dev"

--- a/zrad/radiomics/morphology.py
+++ b/zrad/radiomics/morphology.py
@@ -68,7 +68,9 @@ class MorphologicalFeatures:
         return list(MORPHOLOGY_FEATURE_NAMES)
 
     def _calc_mesh(self, mask_array):
-        mesh_verts, mesh_faces, _, _ = measure.marching_cubes(mask_array, level=0.5)
+        padded_mask = np.pad(mask_array, 1, mode='constant')
+        mesh_verts, mesh_faces, _, _ = measure.marching_cubes(padded_mask, level=0.5)
+        mesh_verts -= np.array([1, 1, 1])
         return mesh_verts * self.spacing, mesh_faces
 
     @staticmethod


### PR DESCRIPTION
Updated morphology mesh extraction to pad masks with a one-voxel constant border before marching_cubes. This is important for masks that touch the image border, where the previous implementation could produce open meshes.