### PR TITLE
CI Add Windows executable build automation

### DIFF
--- a/.github/workflows/windows-exe.yml
+++ b/.github/workflows/windows-exe.yml
@@ -1,0 +1,43 @@
+---
+name: Build Windows executable
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows-exe:
+    name: Build and attach Windows executable
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pyinstaller
+          python -m pip check
+
+      - name: Build executable
+        run: python generate_executable.py
+
+      - name: Attach executable to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $assetName = "z-rad-${{ github.event.release.tag_name }}.exe"
+          if (-not (Test-Path "dist/z-rad.exe")) {
+            throw "Expected executable dist/z-rad.exe was not created."
+          }
+          Copy-Item "dist/z-rad.exe" "dist/$assetName"
+          gh release upload "${{ github.event.release.tag_name }}" "dist/$assetName" --clobber

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ and neighbouring gray level dependance matrix (NGLDM) features families.
 ## Installation and Get Started
 
 ### Windows executable file:
-The simplest way to run Z-Rad on Windows is to start the `z-rad.exe` attached to every Z-Rad release.
+The simplest way to run Z-Rad on Windows is to start the versioned `z-rad-<release-tag>.exe` attached to every Z-Rad release.
 
 ### Windows, Linux, and macOS
 For users familiar with Python programming language, we recommend Python 3.11 or newer:

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -20,7 +20,8 @@ Run The Release Executable
 The simplest way to run the GUI is to start the executable attached to each
 release.
 
-On Windows, use the ``z-rad.exe`` asset distributed with the release package.
+On Windows, use the versioned ``z-rad-<release-tag>.exe`` asset distributed
+with the release package.
 
 Run From A Repository Checkout
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/generate_executable.py
+++ b/generate_executable.py
@@ -24,6 +24,7 @@ PyInstaller.__main__.run(
     [
         'main.py',
         '--onefile',
+        '--name=z-rad',
         f'--icon={icon_path}',
         f'--add-data=docs/logos/icon.ico{add_data_sep}docs/logos',
         f'--add-data=docs/logos/USZLogo.png{add_data_sep}docs/logos',


### PR DESCRIPTION
Set up a GitHub Actions workflow that automatically builds and attaches a versioned Windows executable (z-rad-<tag>.exe) to releases. Updated generate_executable.py to explicitly set the executable name and updated README to reflect the new versioned naming scheme.