### PR TITLE
ENH: SEG Support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))

--- a/docs/user/data_structure.rst
+++ b/docs/user/data_structure.rst
@@ -62,7 +62,7 @@ DICOM Folder Contents
 For DICOM workflows, each case folder should contain:
 
 * exactly one image series for the selected modality
-* zero or one RTSTRUCT file when ROI-based processing is required
+* zero or one RTSTRUCT or DICOM SEG file when ROI-based processing is required
 
 In practice, a DICOM case folder is expected to look like this:
 
@@ -78,10 +78,13 @@ In practice, a DICOM case folder is expected to look like this:
 Notes:
 
 * Z-Rad reads the image series directly from the case folder.
-* For preprocessing, if multiple RTSTRUCT files are present, the first detected
-  file is used.
+* If both RTSTRUCT and SEG objects are present, the first detected RTSTRUCT is
+  used; otherwise, the first detected SEG is used.
+* SEG objects use ``SegmentLabel`` as the structure name. Selected segments are
+  aligned to the source image series using referenced SOP Instance UIDs (with
+  per-frame image position as a fallback).
 * For radiomics extraction, ROI-based DICOM workflows assume that an RTSTRUCT
-  file is available in the case folder.
+  or SEG file is available in the case folder.
 
 NIfTI Folder Contents
 ---------------------

--- a/docs/user/preprocessing.rst
+++ b/docs/user/preprocessing.rst
@@ -161,10 +161,10 @@ For DICOM workflows, the ``Data Type`` selection ``(8)`` exposes the following
 controls:
 
 ``(8.1)`` ``Structures``
-   Enter the names of structures defined in RTSTRUCT files that should be extracted and processed.
+   Enter the ROI names from RTSTRUCT files or ``SegmentLabel`` values from DICOM SEG files that should be extracted and processed.
 
 ``(8.2)`` ``All structures``
-   Process every non-empty structure available in the RTSTRUCT file.
+   Process every non-empty structure available in the RTSTRUCT or SEG file.
 
 ``(8.3)`` ``Convert to NIfTI without resampling``
    Export the DICOM image and selected structures as NIfTI files without

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pydicom
 import pytest
@@ -151,3 +153,40 @@ def test_extract_dicom_mask_returns_empty_image_when_roi_has_no_target_fov_overl
         mask = dicom.extract_dicom_mask(rtstruct_path, "GTV", image)
 
     assert mask.array is None
+
+
+@pytest.mark.unit
+def test_dicom_seg_selects_segment_by_label_and_places_frames(monkeypatch):
+    segment = SimpleNamespace(SegmentNumber=2, SegmentLabel="Tumor lesions")
+    other_segment = SimpleNamespace(SegmentNumber=1, SegmentLabel="Background")
+    group = SimpleNamespace(
+        SegmentIdentificationSequence=[SimpleNamespace(ReferencedSegmentNumber=2)],
+        PlanePositionSequence=[SimpleNamespace(ImagePositionPatient=[0.0, 0.0, 1.0])],
+    )
+    seg = SimpleNamespace(
+        Modality="SEG",
+        SegmentSequence=[other_segment, segment],
+        PerFrameFunctionalGroupsSequence=[group],
+        pixel_array=np.array([[[0, 1, 0, 0, 0]] * 5], dtype=np.uint8),
+    )
+    monkeypatch.setattr(pydicom, "dcmread", lambda *_args, **_kwargs: seg)
+
+    mask = dicom.read_dicom_mask("seg.dcm", "Tumor lesions", _make_sitk_image())
+
+    assert mask.array.shape == (3, 5, 5)
+    assert mask.array[1, 0, 1] == 1
+    assert np.count_nonzero(mask.array[0]) == 0
+
+
+@pytest.mark.unit
+def test_get_all_structure_names_supports_dicom_seg(monkeypatch):
+    seg = SimpleNamespace(
+        Modality="SEG",
+        SegmentSequence=[
+            SimpleNamespace(SegmentNumber=1, SegmentLabel="Tumor lesions"),
+            SimpleNamespace(SegmentNumber=2, SegmentLabel="Liver"),
+        ],
+    )
+    monkeypatch.setattr(pydicom, "dcmread", lambda *_args, **_kwargs: seg)
+
+    assert dicom.get_all_structure_names("seg.dcm") == ["Tumor lesions", "Liver"]

--- a/tests/test_dicom.py
+++ b/tests/test_dicom.py
@@ -9,7 +9,7 @@ from pydicom.sequence import Sequence
 from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 
 import zrad.io.dicom as dicom
-from zrad.exceptions import DataStructureWarning
+from zrad.exceptions import DataStructureError, DataStructureWarning
 
 
 def _make_sitk_image(size=(5, 5, 3)):
@@ -165,6 +165,7 @@ def test_dicom_seg_selects_segment_by_label_and_places_frames(monkeypatch):
     )
     seg = SimpleNamespace(
         Modality="SEG",
+        SegmentationType="BINARY",
         SegmentSequence=[other_segment, segment],
         PerFrameFunctionalGroupsSequence=[group],
         pixel_array=np.array([[[0, 1, 0, 0, 0]] * 5], dtype=np.uint8),
@@ -176,6 +177,42 @@ def test_dicom_seg_selects_segment_by_label_and_places_frames(monkeypatch):
     assert mask.array.shape == (3, 5, 5)
     assert mask.array[1, 0, 1] == 1
     assert np.count_nonzero(mask.array[0]) == 0
+
+
+@pytest.mark.unit
+def test_dicom_seg_accepts_image_position_directly_in_per_frame_group(monkeypatch):
+    group = SimpleNamespace(
+        SegmentIdentificationSequence=[SimpleNamespace(ReferencedSegmentNumber=1)],
+        ImagePositionPatient=[0.0, 0.0, 2.0],
+    )
+    seg = SimpleNamespace(
+        Modality="SEG",
+        SegmentationType="BINARY",
+        SegmentSequence=[SimpleNamespace(SegmentNumber=1, SegmentLabel="Tumor")],
+        PerFrameFunctionalGroupsSequence=[group],
+        pixel_array=np.array([[[1, 0, 0, 0, 0]] * 5], dtype=np.uint8),
+    )
+    monkeypatch.setattr(pydicom, "dcmread", lambda *_args, **_kwargs: seg)
+
+    mask = dicom.read_dicom_mask("seg.dcm", "Tumor", _make_sitk_image())
+
+    assert mask.array.shape == (3, 5, 5)
+    assert mask.array[2, 0, 0] == 1
+    assert np.count_nonzero(mask.array[:2]) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("segmentation_type", ["FRACTIONAL", "LABELMAP", None])
+def test_dicom_seg_rejects_non_binary_segmentation_types(monkeypatch, segmentation_type):
+    seg = SimpleNamespace(
+        Modality="SEG",
+        SegmentSequence=[SimpleNamespace(SegmentNumber=1, SegmentLabel="Tumor")],
+        SegmentationType=segmentation_type,
+    )
+    monkeypatch.setattr(pydicom, "dcmread", lambda *_args, **_kwargs: seg)
+
+    with pytest.raises(DataStructureError, match="Only BINARY segmentations are supported"):
+        dicom.read_dicom_mask("seg.dcm", "Tumor", _make_sitk_image())
 
 
 @pytest.mark.unit

--- a/zrad/batch/preprocessing.py
+++ b/zrad/batch/preprocessing.py
@@ -90,7 +90,7 @@ class BatchPreprocessor:
     structures : sequence of str or str, optional
         Structure names to process. For NIfTI input these are mask file names.
     use_all_structures : bool, optional
-        For DICOM input, process all structures found in the RTSTRUCT.
+        For DICOM input, process all structures found in the RTSTRUCT or SEG object.
     nifti_image_name : str, optional
         Image file name or stem used for NIfTI input.
     just_save_as_nifti : bool, optional
@@ -296,7 +296,7 @@ class BatchPreprocessor:
         if self.input_data_type == 'nifti':
             return list(self.structures or []), None
 
-        rtstructs = get_dicom_files(case_dir, modality='RTSTRUCT')
+        rtstructs = get_dicom_files(case_dir, modality='RTSTRUCT') or get_dicom_files(case_dir, modality='SEG')
         rtstruct_path = rtstructs[0]['file_path'] if rtstructs else None
         if self.use_all_structures and rtstruct_path:
             return get_all_structure_names(rtstruct_path), rtstruct_path
@@ -358,7 +358,12 @@ class BatchPreprocessor:
         if self.input_data_type == 'dicom':
             if not rtstruct_path:
                 return None
-            return Image.from_dicom_mask(rtstruct_path=rtstruct_path, structure_name=structure_name, reference=image)
+            return Image.from_dicom_mask(
+                rtstruct_path=rtstruct_path,
+                structure_name=structure_name,
+                reference=image,
+                dicom_dir=case_dir,
+            )
 
         mask_path = find_nifti_file(case_dir, structure_name)
         if mask_path is None:

--- a/zrad/batch/radiomics.py
+++ b/zrad/batch/radiomics.py
@@ -94,7 +94,7 @@ class BatchRadiomicsExtractor:
         Structure names to extract. For NIfTI input these are mask file names
         and are required.
     use_all_structures : bool, optional
-        For DICOM input, extract all structures found in the RTSTRUCT.
+        For DICOM input, extract all structures found in the RTSTRUCT or SEG object.
     nifti_image_name : str, optional
         Image file name or stem used for NIfTI input.
     nifti_filtered_image_name : str, optional
@@ -349,7 +349,7 @@ class BatchRadiomicsExtractor:
         if self.input_data_type == 'nifti':
             return list(self.structures or []), None
 
-        rtstructs = get_dicom_files(case_dir, modality='RTSTRUCT')
+        rtstructs = get_dicom_files(case_dir, modality='RTSTRUCT') or get_dicom_files(case_dir, modality='SEG')
         rtstruct_path = rtstructs[0]['file_path'] if rtstructs else None
         if self.use_all_structures:
             if not rtstruct_path:
@@ -367,7 +367,12 @@ class BatchRadiomicsExtractor:
         if self.input_data_type == 'dicom':
             if not rtstruct_path:
                 return None
-            return Image.from_dicom_mask(rtstruct_path=rtstruct_path, structure_name=structure_name, reference=image)
+            return Image.from_dicom_mask(
+                rtstruct_path=rtstruct_path,
+                structure_name=structure_name,
+                reference=image,
+                dicom_dir=case_dir,
+            )
 
         mask_path = find_nifti_file(case_dir, structure_name)
         if mask_path is None:

--- a/zrad/gui/_base_tab.py
+++ b/zrad/gui/_base_tab.py
@@ -110,6 +110,7 @@ def load_mask(input_params, patient_folder, structure_name, image):
                 rtstruct_path=input_params['rtstruct_path'],
                 structure_name=structure_name,
                 reference=image,
+                dicom_dir=os.path.join(input_dir, patient_folder),
             )
         except Exception as e:
             error_msg = f"Error reading DICOM mask: {e}"

--- a/zrad/gui/visual_tab.py
+++ b/zrad/gui/visual_tab.py
@@ -39,7 +39,9 @@ def process_patient_folder(input_params, patient_folder, structure_set):
 
     if local_params["input_data_type"] == "dicom":
         input_directory = os.path.join(local_params["input_directory"], patient_folder)
-        rtstruct_paths = get_dicom_files(input_directory, modality="RTSTRUCT")
+        rtstruct_paths = get_dicom_files(input_directory, modality="RTSTRUCT") or get_dicom_files(
+            input_directory, modality="SEG"
+        )
 
         if rtstruct_paths:
             local_params["rtstruct_path"] = rtstruct_paths[0]["file_path"]
@@ -49,7 +51,8 @@ def process_patient_folder(input_params, patient_folder, structure_set):
             local_params["rtstruct_path"] = None
             if current_structure_set or local_params["use_all_structures"]:
                 logger.warning(
-                    f"Patient {patient_folder} has no RTSTRUCT file. Skipping structure/mask loading for this patient."
+                    f"Patient {patient_folder} has no RTSTRUCT or SEG file. "
+                    "Skipping structure/mask loading for this patient."
                 )
             current_structure_set = []
 

--- a/zrad/image.py
+++ b/zrad/image.py
@@ -96,8 +96,8 @@ class Image:
         return cls._from_sitk_image(dicom.read_dicom_image(dicom_dir, modality))
 
     @classmethod
-    def from_dicom_mask(cls, rtstruct_path, structure_name, reference):
-        """Create a DICOM RTSTRUCT mask aligned to a reference image.
+    def from_dicom_mask(cls, rtstruct_path, structure_name, reference, dicom_dir=None):
+        """Create a DICOM RTSTRUCT or SEG mask aligned to a reference image.
 
         Parameters
         ----------
@@ -113,7 +113,7 @@ class Image:
         mask : Image
             Binary mask image aligned to the reference geometry.
         """
-        return dicom.read_dicom_mask(rtstruct_path, structure_name, reference.sitk_image)
+        return dicom.read_dicom_mask(rtstruct_path, structure_name, reference.sitk_image, dicom_dir=dicom_dir)
 
     @classmethod
     def _from_sitk_image(cls, image):

--- a/zrad/io/dicom.py
+++ b/zrad/io/dicom.py
@@ -437,7 +437,14 @@ def _seg_frame_z_index(functional_group, uid_to_slice, image):
         pass
 
     try:
-        position = tuple(map(float, functional_group.PlanePositionSequence[0].ImagePositionPatient))
+        plane_positions = getattr(functional_group, "PlanePositionSequence", None)
+        if plane_positions:
+            position = plane_positions[0].ImagePositionPatient
+        else:
+            # Some producers put Image Position (Patient) directly in the
+            # per-frame item instead of wrapping it in Plane Position Sequence.
+            position = functional_group.ImagePositionPatient
+        position = tuple(map(float, position))
         index = image.TransformPhysicalPointToContinuousIndex(position)
         return int(np.rint(index[2])), None
     except (AttributeError, IndexError, ValueError, RuntimeError) as exc:
@@ -455,6 +462,14 @@ def extract_dicom_seg_mask(seg_path, segment_name, image, dicom_dir=None):
     matching_numbers = {number for number, label in labels.items() if label == segment_name}
     if not matching_numbers:
         return Image()
+
+    raw_segmentation_type = getattr(seg, "SegmentationType", None)
+    segmentation_type = str(raw_segmentation_type).strip().upper() if raw_segmentation_type is not None else ""
+    if segmentation_type != "BINARY":
+        displayed_type = segmentation_type or "missing"
+        raise DataStructureError(
+            f"Unsupported DICOM SEG SegmentationType '{displayed_type}'. Only BINARY segmentations are supported."
+        )
 
     frames = np.asarray(seg.pixel_array)
     if frames.ndim == 2:

--- a/zrad/io/dicom.py
+++ b/zrad/io/dicom.py
@@ -34,8 +34,11 @@ def read_dicom_image(dicom_dir, modality):
     return image
 
 
-def read_dicom_mask(rtstruct_path, structure_name, reference_image):
-    """Read an RTSTRUCT mask as an Image aligned to a reference SimpleITK image."""
+def read_dicom_mask(rtstruct_path, structure_name, reference_image, dicom_dir=None):
+    """Read an RTSTRUCT or DICOM SEG mask aligned to a reference image."""
+    dicom_data = pydicom.dcmread(rtstruct_path, stop_before_pixels=True)
+    if getattr(dicom_data, "Modality", None) == "SEG":
+        return extract_dicom_seg_mask(rtstruct_path, structure_name, reference_image, dicom_dir)
     return extract_dicom_mask(rtstruct_path, structure_name, reference_image)
 
 
@@ -218,6 +221,7 @@ def modality_mapping(modality):
         "CT": "CT",
         "MRI": "MR",
         "RTSTRUCT": "RTSTRUCT",
+        "SEG": "SEG",
         "US": "US",
         "MG": "MG",
         "RTDOSE": "RTDOSE",
@@ -392,9 +396,124 @@ def extract_dicom_mask(rtstruct_path, roi_name, image):
     return Image()
 
 
+def _segment_labels(dicom_data):
+    """Return a SegmentNumber-to-SegmentLabel mapping for a DICOM SEG."""
+    if not hasattr(dicom_data, "SegmentSequence"):
+        raise InvalidDicomError("The DICOM file does not contain a SegmentSequence.")
+    return {
+        int(segment.SegmentNumber): str(getattr(segment, "SegmentLabel", "unknown"))
+        for segment in dicom_data.SegmentSequence
+    }
+
+
+def _source_uid_to_slice(dicom_dir, image):
+    """Map source SOP Instance UIDs to z indices on the reference grid."""
+    uid_to_slice = {}
+    if not dicom_dir:
+        return uid_to_slice
+    for filename in (os.path.join(dicom_dir, name) for name in os.listdir(dicom_dir)):
+        if not os.path.isfile(filename):
+            continue
+        try:
+            source = pydicom.dcmread(filename, stop_before_pixels=True)
+            if not hasattr(source, "SOPInstanceUID") or not hasattr(source, "ImagePositionPatient"):
+                continue
+            index = image.TransformPhysicalPointToContinuousIndex(tuple(map(float, source.ImagePositionPatient)))
+            uid_to_slice[str(source.SOPInstanceUID)] = int(np.rint(index[2]))
+        except (InvalidDicomError, AttributeError, ValueError, RuntimeError):
+            continue
+    return uid_to_slice
+
+
+def _seg_frame_z_index(functional_group, uid_to_slice, image):
+    referenced_uid = None
+    try:
+        referenced_uid = str(
+            functional_group.DerivationImageSequence[0]
+            .SourceImageSequence[0]
+            .ReferencedSOPInstanceUID
+        )
+        if referenced_uid in uid_to_slice:
+            return uid_to_slice[referenced_uid], None
+    except (AttributeError, IndexError):
+        pass
+
+    try:
+        position = tuple(map(float, functional_group.PlanePositionSequence[0].ImagePositionPatient))
+        index = image.TransformPhysicalPointToContinuousIndex(position)
+        return int(np.rint(index[2])), None
+    except (AttributeError, IndexError, ValueError, RuntimeError) as exc:
+        if referenced_uid is not None:
+            return None, referenced_uid
+        raise DataStructureError("SEG frame has neither a usable source-image UID nor image position.") from exc
+
+
+def extract_dicom_seg_mask(seg_path, segment_name, image, dicom_dir=None):
+    """Extract one named segment from a DICOM SEG onto ``image``'s grid."""
+    from ..image import Image
+
+    seg = pydicom.dcmread(seg_path)
+    labels = _segment_labels(seg)
+    matching_numbers = {number for number, label in labels.items() if label == segment_name}
+    if not matching_numbers:
+        return Image()
+
+    frames = np.asarray(seg.pixel_array)
+    if frames.ndim == 2:
+        frames = frames[np.newaxis, ...]
+    width, height, depth = image.GetSize()
+    if frames.shape[1:] != (height, width):
+        raise DataStructureError(
+            f"SEG frame dimensions do not match the image dimensions: SEG={frames.shape[1:]}, "
+            f"image={(height, width)}."
+        )
+    groups = getattr(seg, "PerFrameFunctionalGroupsSequence", None)
+    if groups is None or len(groups) != len(frames):
+        raise DataStructureError("SEG PerFrameFunctionalGroupsSequence does not match its pixel frames.")
+
+    uid_to_slice = _source_uid_to_slice(dicom_dir, image)
+    volume = np.zeros((depth, height, width), dtype=np.uint8)
+    missing_uids = set()
+    for frame, group in zip(frames, groups):
+        try:
+            segment_number = int(group.SegmentIdentificationSequence[0].ReferencedSegmentNumber)
+        except (AttributeError, IndexError, TypeError, ValueError) as exc:
+            raise DataStructureError("SEG frame does not identify its referenced segment.") from exc
+        if segment_number not in matching_numbers:
+            continue
+        z_index, missing_uid = _seg_frame_z_index(group, uid_to_slice, image)
+        if missing_uid is not None:
+            missing_uids.add(missing_uid)
+            continue
+        if z_index < 0 or z_index >= depth:
+            continue
+        volume[z_index] = np.maximum(volume[z_index], (frame > 0).astype(np.uint8))
+
+    if missing_uids:
+        raise DataStructureError(
+            f"{len(missing_uids)} referenced SEG source image(s) were not found in the selected DICOM series."
+        )
+    if not np.any(volume):
+        warnings.warn(
+            f"DICOM SEG segment '{segment_name}' has no overlap with the target image field of view. Segment skipped.",
+            DataStructureWarning,
+        )
+        return Image()
+    return Image(
+        array=volume,
+        origin=image.GetOrigin(),
+        spacing=np.array(image.GetSpacing()),
+        direction=image.GetDirection(),
+        shape=image.GetSize(),
+    )
+
+
 def get_all_structure_names(rtstruct_path):
-    """Extract all structure names from an RTSTRUCT DICOM file."""
+    """Extract all structure names from an RTSTRUCT or DICOM SEG file."""
     dicom_data = pydicom.dcmread(rtstruct_path)
+
+    if getattr(dicom_data, "Modality", None) == "SEG":
+        return list(_segment_labels(dicom_data).values())
 
     if not hasattr(dicom_data, "StructureSetROISequence"):
         raise InvalidDicomError(f"The DICOM file at {rtstruct_path} is not a valid RTSTRUCT file.")

--- a/zrad/io/dicom.py
+++ b/zrad/io/dicom.py
@@ -429,9 +429,7 @@ def _seg_frame_z_index(functional_group, uid_to_slice, image):
     referenced_uid = None
     try:
         referenced_uid = str(
-            functional_group.DerivationImageSequence[0]
-            .SourceImageSequence[0]
-            .ReferencedSOPInstanceUID
+            functional_group.DerivationImageSequence[0].SourceImageSequence[0].ReferencedSOPInstanceUID
         )
         if referenced_uid in uid_to_slice:
             return uid_to_slice[referenced_uid], None
@@ -464,8 +462,7 @@ def extract_dicom_seg_mask(seg_path, segment_name, image, dicom_dir=None):
     width, height, depth = image.GetSize()
     if frames.shape[1:] != (height, width):
         raise DataStructureError(
-            f"SEG frame dimensions do not match the image dimensions: SEG={frames.shape[1:]}, "
-            f"image={(height, width)}."
+            f"SEG frame dimensions do not match the image dimensions: SEG={frames.shape[1:]}, image={(height, width)}."
         )
     groups = getattr(seg, "PerFrameFunctionalGroupsSequence", None)
     if groups is None or len(groups) != len(frames):


### PR DESCRIPTION
As some public datasets provide SEG instead of RTSTRUCT, support for the SEG modality has been added. No user action is required—if both RTSTRUCT and SEG are available, RTSTRUCT is prioritized over SEG.