### PR TITLE
ENH Add Image.resample_to_target for resampling onto another Image grid

### DIFF
--- a/docs/user/api_quickstart.rst
+++ b/docs/user/api_quickstart.rst
@@ -28,6 +28,31 @@ The typical Python workflow is:
 6. Keep the exact preprocessing, filtering, and discretization settings next
    to the extracted features so the run remains reproducible.
 
+Resampling to an Existing Image Grid
+------------------------------------
+
+To align one ``Image`` directly to the complete physical grid of another
+``Image`` (rather than selecting a new voxel spacing), use
+``Image.resample_to_target``. The operation returns a new image, uses the
+moving image's minimum intensity outside its physical extent, and leaves both
+input images unchanged. Save the result separately when a NIfTI file is
+needed.
+
+.. code-block:: python
+
+   import SimpleITK as sitk
+
+   from zrad.image import Image
+
+   moving = Image.from_nifti("path/to/moving.nii.gz")
+   target = Image.from_nifti("path/to/target.nii.gz")
+
+   resampled = moving.resample_to_target(
+       target,
+       interpolator=sitk.sitkLinear,
+   )
+   resampled.save_as_nifti("path/to/resampled.nii.gz")
+
 Canonical Full Pipeline Example
 -------------------------------
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -5,9 +5,9 @@ import SimpleITK as sitk
 from zrad.image import Image
 
 
-def _make_image(array, *, origin=(0.0, 0.0, 0.0), spacing=(1.0, 1.0, 1.0)):
+def _make_image(array, *, origin=(0.0, 0.0, 0.0), spacing=(1.0, 1.0, 1.0), dtype=np.float64):
     return Image(
-        array=np.asarray(array, dtype=np.float64),
+        array=np.asarray(array, dtype=dtype),
         origin=origin,
         spacing=spacing,
         direction=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
@@ -40,3 +40,24 @@ def test_resample_to_target_rejects_non_image_target():
 
     with pytest.raises(TypeError, match="Expected target to be Image"):
         moving.resample_to_target(object())
+
+
+@pytest.mark.unit
+def test_resample_to_target_preserves_linear_interpolation_fractions_for_integer_input():
+    moving = _make_image(np.array([[[0, 1]]]), dtype=np.int16)
+    target = _make_image(np.zeros((1, 1, 3)), spacing=(0.5, 1.0, 1.0))
+
+    resampled = moving.resample_to_target(target)
+
+    assert resampled.array.dtype == np.float64
+    np.testing.assert_array_equal(resampled.array, [[[0.0, 0.5, 1.0]]])
+
+
+@pytest.mark.unit
+def test_resample_to_target_ignores_nan_when_selecting_background_minimum():
+    moving = _make_image(np.array([[[np.nan, 3.0], [2.0, 4.0]]]))
+    target = _make_image(np.zeros((1, 1, 1)), origin=(-2.0, 0.0, 0.0))
+
+    resampled = moving.resample_to_target(target)
+
+    np.testing.assert_array_equal(resampled.array, [[[2.0]]])

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+import SimpleITK as sitk
+
+from zrad.image import Image
+
+
+def _make_image(array, *, origin=(0.0, 0.0, 0.0), spacing=(1.0, 1.0, 1.0)):
+    return Image(
+        array=np.asarray(array, dtype=np.float64),
+        origin=origin,
+        spacing=spacing,
+        direction=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+        shape=(array.shape[2], array.shape[1], array.shape[0]),
+    )
+
+
+@pytest.mark.unit
+def test_resample_to_target_uses_target_grid_and_minimum_background():
+    moving = _make_image(np.array([[[2.0, 4.0], [6.0, 8.0]]]))
+    target = _make_image(
+        np.zeros((1, 3, 4)),
+        origin=(-1.0, 0.0, 0.0),
+        spacing=(0.5, 1.0, 1.0),
+    )
+
+    resampled = moving.resample_to_target(target, interpolator=sitk.sitkNearestNeighbor)
+
+    assert resampled is not moving
+    assert resampled.shape == target.shape
+    assert resampled.origin == target.origin
+    np.testing.assert_array_equal(resampled.spacing, target.spacing)
+    assert resampled.direction == target.direction
+    np.testing.assert_array_equal(resampled.array[0, 0], [2.0, 2.0, 2.0, 4.0])
+
+
+@pytest.mark.unit
+def test_resample_to_target_rejects_non_image_target():
+    moving = _make_image(np.ones((1, 1, 1)))
+
+    with pytest.raises(TypeError, match="Expected target to be Image"):
+        moving.resample_to_target(object())

--- a/zrad/image.py
+++ b/zrad/image.py
@@ -180,8 +180,11 @@ class Image:
         resampler = sitk.ResampleImageFilter()
         resampler.SetReferenceImage(target_image)
         resampler.SetInterpolator(interpolator)
-        resampler.SetOutputPixelType(moving_image.GetPixelID())
-        resampler.SetDefaultPixelValue(float(np.min(self.array)))
+        output_pixel_type = moving_image.GetPixelID()
+        if interpolator != sitk.sitkNearestNeighbor:
+            output_pixel_type = sitk.sitkFloat64
+        resampler.SetOutputPixelType(output_pixel_type)
+        resampler.SetDefaultPixelValue(float(np.nanmin(self.array)))
 
         return self._from_sitk_image(resampler.Execute(moving_image))
 

--- a/zrad/image.py
+++ b/zrad/image.py
@@ -144,6 +144,47 @@ class Image:
             shape=copy.deepcopy(self.shape),
         )
 
+    def resample_to_target(self, target, interpolator=sitk.sitkLinear):
+        """Resample this image onto the physical grid of another image.
+
+        Values outside this image's physical extent are filled with its minimum
+        intensity. The returned image has the target's origin, spacing,
+        direction, and shape; neither input image is modified.
+
+        Parameters
+        ----------
+        target : Image
+            Image whose physical grid defines the resampling output.
+        interpolator : int, optional
+            SimpleITK interpolator enum, such as ``sitk.sitkLinear`` or
+            ``sitk.sitkNearestNeighbor``. The default is linear interpolation.
+
+        Returns
+        -------
+        image : Image
+            A new image containing this image resampled onto ``target``.
+        """
+        if not isinstance(target, Image):
+            raise TypeError(f"Expected target to be Image, got {type(target)}.")
+
+        moving_image = sitk.GetImageFromArray(self.array)
+        moving_image.SetOrigin(self.origin)
+        moving_image.SetSpacing(self.spacing)
+        moving_image.SetDirection(self.direction)
+
+        target_image = sitk.GetImageFromArray(target.array)
+        target_image.SetOrigin(target.origin)
+        target_image.SetSpacing(target.spacing)
+        target_image.SetDirection(target.direction)
+
+        resampler = sitk.ResampleImageFilter()
+        resampler.SetReferenceImage(target_image)
+        resampler.SetInterpolator(interpolator)
+        resampler.SetOutputPixelType(moving_image.GetPixelID())
+        resampler.SetDefaultPixelValue(float(np.min(self.array)))
+
+        return self._from_sitk_image(resampler.Execute(moving_image))
+
     def save_as_nifti(self, output_path):
         """Write the image to a NIfTI file.
 


### PR DESCRIPTION
Resampling an image onto the grid of another image is a useful operation in multimodality imaging, especially for deep learning applications, where not only the image spacing but also the physical image extent (i.e., the number of voxels) should match.