### PR TITLE
REF Make Moran’s I and Geary’s C efficient standard morphology features

### DIFF
--- a/docs/user/radiomics.rst
+++ b/docs/user/radiomics.rst
@@ -82,8 +82,10 @@ The implementation includes features from these groups:
 In the GUI, the standard workflow exposes morphological, local intensity,
 first-order, histogram, GLCM, GLRLM, GLSZM, and GLDZM features.
 
-**Note:** Intensity-volume histogram features and the computationally
-expensive Moran's I and Geary's C measures remain API-only.
+**Note:** Intensity-volume histogram features remain API-only.
+
+Moran's I (``morph_moran_i``) and Geary's C (``morph_geary_c``) are included
+in 3D morphology features in both the GUI and API.
 
 Validation Constraints
 ----------------------
@@ -130,9 +132,7 @@ Practical Notes
 * The upper workflow section ``(1)`` uses the same dataset-selection logic as
   preprocessing and filtering.
 * The choice of extraction parameters should be kept consistent across all analyzed cases.
-* Intensity-volume histogram features and computationally expensive measures
-  such as Moran's I and Geary's C are not exposed in the GUI and remain
-  available through the API only.
+* Intensity-volume histogram features remain available through the API only.
 * API users should prepare ``RoiData.texture_discretized_image`` before
   requesting histogram or texture families.
 * API users should prepare ``RoiData.ivh_intensity_image`` with

--- a/tests/test_batch_radiomics.py
+++ b/tests/test_batch_radiomics.py
@@ -593,3 +593,34 @@ def test_gui_mapping_creates_dicom_batch_radiomics_extractor_with_all_structures
     assert extractor.input_data_type == 'dicom'
     assert extractor.structures is None
     assert extractor.use_all_structures is True
+
+
+@pytest.mark.unit
+def test_gui_workflow_writes_moran_and_geary_columns(tmp_path):
+    input_dir, output_dir = tmp_path / 'input', tmp_path / 'output'
+    case_dir = _write_case(input_dir, 'case_a', masks=['mask'])
+    values = np.arange(1, 217, dtype=float).reshape(6, 6, 6)
+    mask = np.zeros_like(values)
+    mask[1:5, 1:4, 1:4] = 1
+    mask[4, 3, 3] = 0
+    _make_image(values).save_as_nifti(case_dir / 'image.nii.gz')
+    _make_image(mask).save_as_nifti(case_dir / 'mask.nii.gz')
+    extractor = create_batch_radiomics_extractor_from_input_params(
+        _gui_input_params(
+            input_directory=str(input_dir),
+            output_directory=str(output_dir),
+            number_of_threads=1,
+            intensity_range=None,
+            outlier_range=None,
+            aggregation_method=('3D', 'MERG'),
+            weighting='Mean',
+        ),
+        parallel_backend='threads',
+    )
+    result = extractor.run()
+    assert result.processed_count == 1
+    with (output_dir / 'radiomics.csv').open() as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert np.isfinite(float(rows[0]['morph_moran_i']))
+    assert np.isfinite(float(rows[0]['morph_geary_c']))

--- a/tests/test_ibsi_1.py
+++ b/tests/test_ibsi_1.py
@@ -364,3 +364,42 @@ def test_ibsi_i_config_e(res3d_2mm_image_spline, res3d_2mm_mask_linear):
         ivh_number_of_bins=1000,
     )
     ibsi_i_validation(ibsi_features, features)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize('config', list('ABCDE'))
+@pytest.mark.parametrize('method', ['fft', 'blocked'])
+def test_ibsi_i_morphology_correlation(config, method, request, monkeypatch):
+    from zrad.radiomics import morphology
+
+    fixture_names = {
+        'A': ('dcm_ct_phantom_image', 'dcm_ct_phantom_mask'),
+        'B': ('res2d_2mm_image_linear', 'res2d_2mm_mask_linear'),
+        'C': ('res3d_2mm_image_linear', 'res3d_2mm_mask_linear'),
+        'D': ('res3d_2mm_image_linear', 'res3d_2mm_mask_linear'),
+        'E': ('res3d_2mm_image_spline', 'res3d_2mm_mask_linear'),
+    }
+    image, mask = (request.getfixturevalue(name) for name in fixture_names[config])
+    roi = _prepare_roi_data(
+        image,
+        mask,
+        intensity_range=[-500, 400] if config in 'AB' else [-1000, 400] if config in 'CE' else None,
+        outlier_range=3 if config in 'DE' else None,
+    )
+    original_selector = morphology._correlation_method
+
+    def select(n, shape):
+        assert original_selector(n, shape) == 'fft'
+        # Validate both exact algorithms on the same reference fixtures.
+        return method
+
+    monkeypatch.setattr(morphology, '_correlation_method', select)
+    features = Radiomics().extract_features(roi_data=roi, families=['morphology'])
+    tags = {'morph_moran_i', 'morph_geary_c'}
+    assert set(features) == set(morphology.MORPHOLOGY_FEATURE_NAMES)
+    references = ibsi_i_feature_tolerances('config_' + config)
+    for tag in tags:
+        assert features[tag] == pytest.approx(
+            float(references[tag]['reference value']),
+            abs=float(references[tag]['tolerance']),
+        )

--- a/tests/test_morphology_correlation.py
+++ b/tests/test_morphology_correlation.py
@@ -1,0 +1,178 @@
+"""Independent direct oracles and dispatch tests for full inverse-distance features."""
+
+import csv
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.spatial.distance import pdist, squareform
+
+from zrad.exceptions import DataStructureError
+from zrad.radiomics import morphology
+from zrad.radiomics.morphology import MorphologyCorrelationFeatures
+
+TAGS = ('morph_moran_i', 'morph_geary_c')
+
+
+def direct(mask, image, spacing):
+    # The previous dense definition, using float64 to avoid integer overflow.
+    indices = np.argwhere(mask)
+    values = image[tuple(indices.T)].astype(np.float64)
+    valid = ~np.isnan(values)
+    values, indices = values[valid], indices[valid]
+    weights = squareform(pdist(indices * spacing))
+    np.fill_diagonal(weights, np.inf)
+    weights = 1 / weights
+    z = values - values.mean()
+    q = np.sum(z**2)
+    n = len(values)
+    return {
+        TAGS[0]: n / weights.sum() * np.sum(weights * np.outer(z, z)) / q,
+        TAGS[1]: (n - 1) / (2 * weights.sum()) * np.sum(weights * (values[:, None] - values) ** 2) / q,
+    }
+
+
+@pytest.fixture(params=['blocked', 'fft'])
+def method(request, monkeypatch):
+    monkeypatch.setattr(morphology, '_correlation_method', lambda *args: request.param)
+    return request.param
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('shape', [(1, 1, 2), (1, 5, 9), (7, 8, 9), (9, 10, 11)])
+@pytest.mark.parametrize('spacing', [(1, 1, 1), (3, 0.977, 0.81), (0.001, 100, 0.3)])
+@pytest.mark.parametrize('occupancy', [0.15, 0.7, 1])
+def test_matches_dense_definition(method, shape, spacing, occupancy):
+    rng = np.random.default_rng(913)
+    mask = rng.random(shape) < occupancy
+    mask.flat[0] = mask.flat[-1] = True
+    image = rng.normal(-200, 100, shape)
+    image[(rng.random(shape) < 0.1) & ~mask] = np.nan
+    if mask.sum() > 2:
+        image.flat[np.flatnonzero(mask)[1]] = np.nan
+    before = image.copy()
+    expected = direct(mask, image, spacing)
+    actual = MorphologyCorrelationFeatures(spacing).calculate_features(mask, image)
+    assert actual == pytest.approx(expected, abs=2e-12, rel=2e-12)
+    np.testing.assert_array_equal(image, before)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('dtype', [np.int16, np.int32, np.float32, np.float64])
+def test_dtype_and_geometry_invariance(method, dtype):
+    rng = np.random.default_rng(41)
+    image = rng.integers(-1000, 401, (5, 6, 7)).astype(dtype)
+    mask = rng.random(image.shape) > 0.3
+    spacing = np.array([2.5, 0.8, 1.1])
+    expected = direct(mask, image, spacing)
+    calc = MorphologyCorrelationFeatures(spacing)
+    assert calc.calculate_features(mask, image) == pytest.approx(expected, abs=2e-12)
+    assert calc.calculate_features(np.pad(mask, 5), np.pad(image, 5)) == pytest.approx(expected, abs=2e-12)
+    assert calc.calculate_features(mask, image.astype(float) * -3 + 1e9) == pytest.approx(expected, abs=2e-12)
+    permuted = MorphologyCorrelationFeatures(spacing[[2, 0, 1]])
+    assert permuted.calculate_features(mask.transpose(2, 0, 1), image.transpose(2, 0, 1)) == pytest.approx(
+        expected, abs=2e-12
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('count', [0, 1])
+def test_empty_or_singleton_is_nan(count):
+    mask = np.zeros((3, 3, 3))
+    mask.flat[:count] = 1
+    result = MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(mask, mask)
+    assert all(np.isnan(v) for v in result.values())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('value', [np.inf, -np.inf])
+def test_infinity_propagates_without_changing_population(value):
+    image = np.arange(27, dtype=float).reshape(3, 3, 3)
+    image.flat[0] = value
+    result = MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones_like(image), image)
+    assert all(np.isnan(v) for v in result.values())
+
+
+@pytest.mark.unit
+def test_constant_detected_before_spatial_work(monkeypatch):
+    def unexpected(*args):
+        pytest.fail('Constant intensities should not reach the selector')
+
+    monkeypatch.setattr(morphology, '_correlation_method', unexpected)
+    with pytest.raises(DataStructureError, match='constant'):
+        MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones((3, 3, 3)), np.ones((3, 3, 3)))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('spacing', [(0, 1, 1), (-1, 1, 1), (np.nan, 1, 1), (np.inf, 1, 1), (1, 1)])
+def test_invalid_spacing(spacing):
+    with pytest.raises(ValueError, match='positive finite'):
+        MorphologyCorrelationFeatures(spacing).calculate_features(np.ones((3, 3, 3)), np.arange(27).reshape(3, 3, 3))
+
+
+@pytest.mark.unit
+def test_selector_uses_population_and_geometry():
+    select = morphology._correlation_method
+    assert select(74, (7, 7, 9)) == 'blocked'
+    assert select(256, (1, 1, 511)) == 'blocked'
+    assert select(257, (1, 1, 513)) == 'fft'
+    assert select(1000, (32, 25, 21)) == 'fft'
+    assert select(1000, (256, 256, 256)) == 'blocked'
+    assert select(2_000_000, (512, 512, 512)) == 'fft'
+
+
+@pytest.mark.unit
+def test_selector_receives_valid_intensity_population_and_cropped_geometry(monkeypatch):
+    image = np.full((20, 21, 22), np.nan)
+    image[5, 6, 7], image[7, 9, 11] = 1, 3
+    original = morphology._correlation_method
+    calls = []
+
+    def select(n, fft_shape):
+        calls.append((n, fft_shape))
+        return original(n, fft_shape)
+
+    monkeypatch.setattr(morphology, '_correlation_method', select)
+    result = MorphologyCorrelationFeatures((2, 1, 1)).calculate_features(np.ones_like(image), image)
+    assert calls == [(2, (5, 7, 9))]
+    assert result == pytest.approx({'morph_moran_i': -1, 'morph_geary_c': 1})
+
+
+@pytest.mark.unit
+def test_selector_cost_boundary(monkeypatch):
+    # For P=1024 and N=1000, equality must choose blocked.
+    pairs = 1000 * 999 // 2
+    monkeypatch.setattr(morphology, '_CORRELATION_FFT_COST_FACTOR', pairs / (1024 * 10))
+    assert morphology._correlation_method(1000, (1, 1, 1024)) == 'blocked'
+    monkeypatch.setattr(morphology, '_CORRELATION_FFT_COST_FACTOR', pairs / (1024 * 10) - 1e-6)
+    assert morphology._correlation_method(1000, (1, 1, 1024)) == 'fft'
+
+
+@pytest.mark.unit
+def test_digital_phantom_reference(method):
+    # Official IBSI digital phantom, z/y/x order, 2 mm isotropic voxels.
+    image = np.array(
+        [
+            [[1, 4, 4, 1, 1], [1, 4, 6, 1, 1], [4, 1, 6, 4, 1], [4, 4, 6, 4, 1]],
+            [[1, 4, 4, 1, 1], [1, 1, 6, 1, 1], [1, 1, 3, 1, 1], [4, 4, 6, 1, 1]],
+            [[1, 4, 4, 1, 1], [1, 1, 1, 1, 1], [1, 1, 9, 1, 1], [1, 1, 6, 1, 1]],
+            [[1, 4, 4, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 6, 1, 1]],
+        ]
+    )
+    mask = np.ones_like(image)
+    mask[1, 2, 0] = mask[2, 2, 2] = 0
+    mask[2:, 0, 3:] = 0
+    actual = MorphologyCorrelationFeatures((2, 2, 2)).calculate_features(mask, image)
+    assert set(actual) == set(TAGS)
+    with (Path(__file__).parent / 'data/ibsi_1_reference_values_digital_phantom.csv').open() as f:
+        refs = {r['tag']: r for r in csv.DictReader(f)}
+    for tag in TAGS:
+        assert actual[tag] == pytest.approx(float(refs[tag]['reference value']), abs=float(refs[tag]['tolerance']))
+    assert actual == pytest.approx(direct(mask, image, (2, 2, 2)), abs=2e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('shape', [(3, 3), (3, 3, 4)])
+def test_misaligned_input_rejected(shape):
+    with pytest.raises(ValueError, match='aligned 3D'):
+        MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones((3, 3, 3)), np.ones(shape))

--- a/tests/test_morphology_correlation.py
+++ b/tests/test_morphology_correlation.py
@@ -172,6 +172,38 @@ def test_digital_phantom_reference(method):
 
 
 @pytest.mark.unit
+def test_api_uses_resegmented_intensities_not_texture_bins():
+    from zrad.image import Image
+    from zrad.preprocessing import IntensityMaskBuilder, Resegmenter, RoiData, TextureDiscretizer
+    from zrad.radiomics import Radiomics
+
+    array = np.arange(4 * 5 * 6, dtype=float).reshape(4, 5, 6) - 60
+
+    def image(values):
+        return Image(
+            array=values,
+            origin=(0, 0, 0),
+            spacing=np.array([0.8, 1.1, 2.5]),
+            direction=(1, 0, 0, 0, 1, 0, 0, 0, 1),
+            shape=(6, 5, 4),
+        )
+
+    mask = np.ones_like(array)
+    mask[1, 2, 3] = 0
+    roi = IntensityMaskBuilder().apply(RoiData(image=image(array), morphological_mask=image(mask)))
+    roi = Resegmenter(intensity_range=[-30, 50]).apply(roi)
+    roi = TextureDiscretizer(number_of_bins=4).apply(roi)
+    expected = direct(mask, np.where((array >= -30) & (array <= 50), array, np.nan), (2.5, 1.1, 0.8))
+    extractor = Radiomics()
+    actual = extractor.extract_features(roi_data=roi, features=list(TAGS))
+    assert actual == pytest.approx(expected, abs=2e-12)
+    for tag in TAGS:
+        assert extractor.extract_features(roi_data=roi, features=[tag]) == pytest.approx(
+            {tag: expected[tag]}, abs=2e-12
+        )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize('shape', [(3, 3), (3, 3, 4)])
 def test_misaligned_input_rejected(shape):
     with pytest.raises(ValueError, match='aligned 3D'):

--- a/tests/test_morphology_correlation.py
+++ b/tests/test_morphology_correlation.py
@@ -93,12 +93,14 @@ def test_infinity_propagates_without_changing_population(value):
 
 
 @pytest.mark.unit
-def test_constant_detected_before_spatial_work(monkeypatch):
+@pytest.mark.parametrize('shape', [(4, 5, 6), (10, 10, 10)])
+@pytest.mark.parametrize('value', [0.1, 1.1, 50.0])
+def test_constant_detected_before_spatial_work(monkeypatch, shape, value):
     def unexpected(*args):
         pytest.fail('Constant intensities should not reach the selector')
 
     monkeypatch.setattr(morphology, '_correlation_method', unexpected)
-    result = MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones((3, 3, 3)), np.ones((3, 3, 3)))
+    result = MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones(shape), np.full(shape, value))
     assert set(result) == set(TAGS)
     assert all(np.isnan(value) for value in result.values())
 
@@ -208,3 +210,12 @@ def test_api_uses_resegmented_intensities_not_texture_bins():
 def test_misaligned_input_rejected(shape):
     with pytest.raises(ValueError, match='aligned 3D'):
         MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones((3, 3, 3)), np.ones(shape))
+
+
+@pytest.mark.unit
+def test_low_contrast_is_not_treated_as_constant(method):
+    image = 0.1 + np.arange(120).reshape(4, 5, 6) * 1e-12
+    mask = np.ones_like(image)
+    result = MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(mask, image)
+    assert all(np.isfinite(value) for value in result.values())
+    assert result == pytest.approx(direct(mask, image, (1, 1, 1)), abs=2e-12, rel=2e-12)

--- a/tests/test_morphology_correlation.py
+++ b/tests/test_morphology_correlation.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from scipy.spatial.distance import pdist, squareform
 
-from zrad.exceptions import DataStructureError
 from zrad.radiomics import morphology
 from zrad.radiomics.morphology import MorphologyCorrelationFeatures
 
@@ -99,8 +98,9 @@ def test_constant_detected_before_spatial_work(monkeypatch):
         pytest.fail('Constant intensities should not reach the selector')
 
     monkeypatch.setattr(morphology, '_correlation_method', unexpected)
-    with pytest.raises(DataStructureError, match='constant'):
-        MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones((3, 3, 3)), np.ones((3, 3, 3)))
+    result = MorphologyCorrelationFeatures((1, 1, 1)).calculate_features(np.ones((3, 3, 3)), np.ones((3, 3, 3)))
+    assert set(result) == set(TAGS)
+    assert all(np.isnan(value) for value in result.values())
 
 
 @pytest.mark.unit

--- a/tests/test_radiomics.py
+++ b/tests/test_radiomics.py
@@ -281,6 +281,7 @@ def test_morphology_includes_correlation_once(families, monkeypatch):
         {'features': ['morph_moran_i']},
         {'features': ['morph_geary_c']},
         {'features': ['morph_moran_i', 'morph_geary_c', 'morph_moran_i']},
+        {'features': ['morph_volume', 'morph_geary_c', 'morph_moran_i']},
     ],
 )
 def test_morphology_individual_selection(selection, monkeypatch):
@@ -291,14 +292,16 @@ def test_morphology_individual_selection(selection, monkeypatch):
     roi = _roi_data(image, _make_image(mask_array))
     expected = Radiomics().extract_features(roi_data=roi, families=['morphology'])
     assert set(expected) == set(MorphologicalFeatures((1, 1, 1)).get_feature_names())
-    original = MorphologicalFeatures.calculate_features
+    from zrad.radiomics.morphology import MorphologyCorrelationFeatures
+
+    original = MorphologyCorrelationFeatures.calculate_features
     calls = []
 
     def calculate(self, *args):
         calls.append(1)
         return original(self, *args)
 
-    monkeypatch.setattr(MorphologicalFeatures, 'calculate_features', calculate)
+    monkeypatch.setattr(MorphologyCorrelationFeatures, 'calculate_features', calculate)
     result = Radiomics().extract_features(roi_data=roi, **selection)
     tags = set(selection.get('features', expected))
     assert result == pytest.approx({tag: expected[tag] for tag in tags})
@@ -334,3 +337,57 @@ def test_constant_intensity_preserves_morphology_results(selection):
         assert all(np.isfinite(value) for tag, value in result.items() if tag not in {'morph_moran_i', 'morph_geary_c'})
     else:
         assert set(result) == {'morph_volume'}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('zero_sum', [False, True])
+@pytest.mark.parametrize(
+    'features',
+    [
+        ['morph_moran_i'],
+        ['morph_geary_c'],
+        ['morph_geary_c', 'stat_mean', 'morph_moran_i', 'morph_geary_c'],
+    ],
+)
+def test_correlation_selection_avoids_unrelated_shape_failures(zero_sum, features, monkeypatch):
+    from zrad.radiomics.morphology import MorphologyCorrelationFeatures
+
+    values = np.arange(1, 126, dtype=float).reshape(5, 5, 5)
+    if zero_sum:
+        values -= values.mean()
+    image = _make_image(values)
+    mask = np.ones_like(values)
+    roi = _roi_data(image, _make_image(mask))
+    # Direct pairwise definition for this cube, independently validated on master.
+    expected = {'morph_moran_i': 0.19822002516539844, 'morph_geary_c': 0.7404778956266241, 'stat_mean': values.mean()}
+    original = MorphologyCorrelationFeatures.calculate_features
+    calls = []
+
+    def calculate(self, *args):
+        calls.append(1)
+        return original(self, *args)
+
+    def unexpected(*args, **kwargs):
+        pytest.fail('Correlation-only morphology selection must not evaluate shape features')
+
+    monkeypatch.setattr(MorphologicalFeatures, 'calculate_features', unexpected)
+    monkeypatch.setattr(MorphologyCorrelationFeatures, 'calculate_features', calculate)
+    result = Radiomics().extract_features(roi_data=roi, features=features)
+    assert result == pytest.approx({name: expected[name] for name in features}, abs=2e-12)
+    assert list(result) == list(dict.fromkeys(features))
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+def test_shape_selection_skips_spatial_calculation(monkeypatch):
+    from zrad.radiomics.morphology import MorphologyCorrelationFeatures
+
+    image = _make_image(np.full((4, 5, 6), 50.0))
+    roi = _roi_data(image, _make_image(np.ones_like(image.array)))
+
+    def unexpected(*args):
+        pytest.fail('Shape-only selection must not evaluate Moran or Geary')
+
+    monkeypatch.setattr(MorphologyCorrelationFeatures, 'calculate_features', unexpected)
+    result = Radiomics().extract_features(roi_data=roi, features=['morph_volume'])
+    assert result == pytest.approx({'morph_volume': 113.16666666666667})

--- a/tests/test_radiomics.py
+++ b/tests/test_radiomics.py
@@ -319,3 +319,18 @@ def test_removed_correlation_family_is_rejected():
     roi = _roi_data(image, _make_image(np.ones_like(image.array)))
     with pytest.raises(ValueError, match="Feature family 'morphology_correlation' is not supported"):
         Radiomics().extract_features(roi_data=roi, families=['morphology_correlation'])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('selection', [{}, {'families': ['morphology']}, {'features': ['morph_volume']}])
+def test_constant_intensity_preserves_morphology_results(selection):
+    image = _make_image(np.full((4, 5, 6), 50.0))
+    roi = _roi_data(image, _make_image(np.ones_like(image.array)))
+    result = Radiomics().extract_features(roi_data=roi, **selection)
+    assert result['morph_volume'] == pytest.approx(113.16666666666667)
+    if 'features' not in selection:
+        assert np.isnan(result['morph_moran_i'])
+        assert np.isnan(result['morph_geary_c'])
+        assert all(np.isfinite(value) for tag, value in result.items() if tag not in {'morph_moran_i', 'morph_geary_c'})
+    else:
+        assert set(result) == {'morph_volume'}

--- a/tests/test_radiomics.py
+++ b/tests/test_radiomics.py
@@ -107,7 +107,8 @@ def test_default_extraction_uses_available_prepared_families():
     assert 'ih_mean' in features
     assert 'cm_joint_max_3D_avg' in features
     assert 'ivh_v10' not in features
-    assert 'morph_moran_i' not in features
+    assert 'morph_moran_i' in features
+    assert 'morph_geary_c' in features
 
 
 @pytest.mark.unit
@@ -236,3 +237,85 @@ def test_gldzm_distances_use_morphological_mask_after_resegmentation_edges_are_e
 
     assert features['dzm_sde'] == pytest.approx(0.25)
     assert features['dzm_lde'] == pytest.approx(4.0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'families',
+    [
+        None,
+        ['morphology'],
+        ['morphology', 'morphology'],
+        'all',
+    ],
+)
+def test_morphology_includes_correlation_once(families, monkeypatch):
+    from zrad.radiomics.morphology import MorphologyCorrelationFeatures
+
+    image = _make_image(np.arange(1, 217, dtype=float).reshape(6, 6, 6))
+    mask_array = np.zeros_like(image.array)
+    mask_array[1:5, 1:4, 1:4] = 1
+    mask_array[4, 3, 3] = 0
+    mask = _make_image(mask_array)
+    roi = TextureDiscretizer(number_of_bins=4).apply(_roi_data(image, mask))
+    roi = IVHIntensityDiscretizer(method='direct').apply(roi)
+    expected = Radiomics().extract_features(roi_data=roi, families=['morphology'])
+    original = MorphologyCorrelationFeatures.calculate_features
+    calls = []
+
+    def calculate(self, *args):
+        calls.append(1)
+        return original(self, *args)
+
+    monkeypatch.setattr(MorphologyCorrelationFeatures, 'calculate_features', calculate)
+    result = Radiomics().extract_features(roi_data=roi, families=families)
+    assert 'morph_volume' in result
+    assert {tag: result[tag] for tag in expected} == pytest.approx(expected)
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'selection',
+    [
+        {'features': ['morph_moran_i']},
+        {'features': ['morph_geary_c']},
+        {'features': ['morph_moran_i', 'morph_geary_c', 'morph_moran_i']},
+    ],
+)
+def test_morphology_individual_selection(selection, monkeypatch):
+    image = _make_image(np.arange(1, 217, dtype=float).reshape(6, 6, 6))
+    mask_array = np.zeros_like(image.array)
+    mask_array[1:5, 1:4, 1:4] = 1
+    mask_array[4, 3, 3] = 0
+    roi = _roi_data(image, _make_image(mask_array))
+    expected = Radiomics().extract_features(roi_data=roi, families=['morphology'])
+    assert set(expected) == set(MorphologicalFeatures((1, 1, 1)).get_feature_names())
+    original = MorphologicalFeatures.calculate_features
+    calls = []
+
+    def calculate(self, *args):
+        calls.append(1)
+        return original(self, *args)
+
+    monkeypatch.setattr(MorphologicalFeatures, 'calculate_features', calculate)
+    result = Radiomics().extract_features(roi_data=roi, **selection)
+    tags = set(selection.get('features', expected))
+    assert result == pytest.approx({tag: expected[tag] for tag in tags})
+    assert len(calls) == 1
+
+
+@pytest.mark.unit
+def test_slice_image_still_omits_3d_morphology():
+    image = _make_image(np.arange(36, dtype=float).reshape(1, 6, 6))
+    roi = _roi_data(image, _make_image(np.ones_like(image.array)))
+    result = Radiomics().extract_features(roi_data=roi)
+    assert not any(tag.startswith('morph_') for tag in result)
+
+
+@pytest.mark.unit
+def test_removed_correlation_family_is_rejected():
+    image = _make_image(np.arange(27, dtype=float).reshape(3, 3, 3))
+    roi = _roi_data(image, _make_image(np.ones_like(image.array)))
+    with pytest.raises(ValueError, match="Feature family 'morphology_correlation' is not supported"):
+        Radiomics().extract_features(roi_data=roi, families=['morphology_correlation'])

--- a/tests/test_radiomics.py
+++ b/tests/test_radiomics.py
@@ -326,8 +326,9 @@ def test_removed_correlation_family_is_rejected():
 
 @pytest.mark.unit
 @pytest.mark.parametrize('selection', [{}, {'families': ['morphology']}, {'features': ['morph_volume']}])
-def test_constant_intensity_preserves_morphology_results(selection):
-    image = _make_image(np.full((4, 5, 6), 50.0))
+@pytest.mark.parametrize('value', [0.1, 1.1, 50.0])
+def test_constant_intensity_preserves_morphology_results(selection, value):
+    image = _make_image(np.full((4, 5, 6), value))
     roi = _roi_data(image, _make_image(np.ones_like(image.array)))
     result = Radiomics().extract_features(roi_data=roi, **selection)
     assert result['morph_volume'] == pytest.approx(113.16666666666667)

--- a/zrad/radiomics/base.py
+++ b/zrad/radiomics/base.py
@@ -19,3 +19,10 @@ class BaseFeatureGroup:
 
     def calculate(self, context, prepared_data):
         raise NotImplementedError
+
+    def calculate_selected(self, context, prepared_data, selected_features):
+        """Evaluate selected outputs; groups may avoid unrelated calculations.
+
+        The extractor still filters and orders the returned feature dictionary.
+        """
+        return self.calculate(context, prepared_data)

--- a/zrad/radiomics/extractor.py
+++ b/zrad/radiomics/extractor.py
@@ -25,11 +25,10 @@ class Radiomics:
     * ``"ngtdm"``
     * ``"ngldm"``
     * ``"ivh"``
-    * ``"morphology_correlation"``
 
-    ``"morphology_correlation"`` contains Moran's I and Geary's C. It is
-    supported for 3D ROIs but is not extracted by default because it can be
-    computationally expensive.
+    ``"morphology"`` includes Moran's I and Geary's C for 3D ROIs, including
+    default extraction. Both share an exact hybrid FFT or blocked calculation.
+    They can also be selected by their individual feature names.
 
     Parameters
     ----------
@@ -89,13 +88,12 @@ class Radiomics:
             ``"morphology"``, ``"local_intensity"``,
             ``"intensity_statistics"``, ``"intensity_histogram"``,
             ``"glcm"``, ``"glrlm"``, ``"glszm"``, ``"gldzm"``,
-            ``"ngtdm"``, ``"ngldm"``, ``"ivh"``, and
-            ``"morphology_correlation"``.
+            ``"ngtdm"``, ``"ngldm"``, and ``"ivh"``.
 
             If omitted, all default-enabled families supported by the prepared
             ``RoiData`` are extracted. Use ``"all"`` to extract every
-            supported family, including ``"morphology_correlation"``.
-            Repeated family names are ignored.
+            supported family. Morphology includes Moran's I and Geary's C.
+            Repeated family selections are calculated once.
         features : str or sequence of str, optional
             Individual feature names to extract. Names may come from one or
             more feature families. Use either ``families`` or ``features``,
@@ -127,7 +125,7 @@ class Radiomics:
         -----
         Feature availability depends on the prepared ``RoiData``:
 
-        * ``"morphology"`` and ``"morphology_correlation"`` require a 3D ROI.
+        * ``"morphology"`` requires a 3D ROI.
         * ``"intensity_histogram"`` and texture families require
           ``texture_discretized_image``.
         * ``"ivh"`` requires ``ivh_intensity_image`` and IVH discretization

--- a/zrad/radiomics/extractor.py
+++ b/zrad/radiomics/extractor.py
@@ -143,7 +143,11 @@ class Radiomics:
 
         extracted = {}
         for group in groups:
-            extracted.update(group.calculate(context, prepared_data))
+            if selected_features is None:
+                extracted.update(group.calculate(context, prepared_data))
+            else:
+                group_features = [name for name in selected_features if name in group.output_names(context)]
+                extracted.update(group.calculate_selected(context, prepared_data, group_features))
 
         if selected_features is not None:
             extracted = {name: extracted[name] for name in selected_features}

--- a/zrad/radiomics/feature_registry.py
+++ b/zrad/radiomics/feature_registry.py
@@ -9,7 +9,7 @@ from .intensity import (
     IVHFeatureGroup,
     LocalIntensityFeatureGroup,
 )
-from .morphology import MorphologyCorrelationFeatureGroup, MorphologyFeatureGroup
+from .morphology import MorphologyFeatureGroup
 from .ngldm import NGLDMFeatureGroup
 from .ngtdm import NGTDMFeatureGroup
 
@@ -25,7 +25,6 @@ DEFAULT_GROUP_ORDER = (
     'ngtdm',
     'ngldm',
     'ivh',
-    'morphology_correlation',
 )
 
 
@@ -33,7 +32,6 @@ FEATURE_GROUPS = {
     group.family: group
     for group in (
         MorphologyFeatureGroup(),
-        MorphologyCorrelationFeatureGroup(),
         LocalIntensityFeatureGroup(),
         IntensityStatisticsFeatureGroup(),
         IntensityHistogramFeatureGroup(),

--- a/zrad/radiomics/morphology.py
+++ b/zrad/radiomics/morphology.py
@@ -234,7 +234,7 @@ class MorphologicalFeatures:
     def _calc_integrated_intensity(image_array, vol_mesh):
         return np.nanmean(image_array) * vol_mesh
 
-    def calculate_features(self, mask_array, image_array):
+    def calculate_features(self, mask_array, image_array, *, include_correlation=True):
         """Calculate morphology features for prepared mask and intensity arrays.
 
         Parameters
@@ -244,6 +244,8 @@ class MorphologicalFeatures:
         image_array : numpy.ndarray
             Prepared intensity image aligned with ``mask_array`` where voxels
             outside the ROI can be represented by ``NaN``.
+        include_correlation : bool, default=True
+            Include the joint Moran's I and Geary's C calculation.
 
         Returns
         -------
@@ -301,9 +303,10 @@ class MorphologicalFeatures:
             area_density_ch,
             integrated_intensity,
         ]
-        correlation = MorphologyCorrelationFeatures(self.spacing).calculate_features(mask_array, image_array)
-        values.extend(correlation[name] for name in MORPHOLOGY_CORRELATION_FEATURE_NAMES)
-        return dict(zip(MORPHOLOGY_FEATURE_NAMES, values))
+        features = dict(zip(MORPHOLOGY_FEATURE_NAMES, values))
+        if include_correlation:
+            features.update(MorphologyCorrelationFeatures(self.spacing).calculate_features(mask_array, image_array))
+        return features
 
 
 class MorphologyCorrelationFeatures:
@@ -518,4 +521,20 @@ class MorphologyFeatureGroup(BaseFeatureGroup):
         return morphology.calculate_features(
             masks.morphological_mask.array,
             masks.intensity_mask.array,
+        )
+
+    def calculate_selected(self, context, prepared_data, selected_features):
+        masks = prepared_data.require_base_masks()
+        spacing = masks.morphological_mask.spacing[::-1]
+        correlation_names = set(MORPHOLOGY_CORRELATION_FEATURE_NAMES)
+        selected = set(selected_features)
+        if selected <= correlation_names:
+            return MorphologyCorrelationFeatures(spacing).calculate_features(
+                masks.morphological_mask.array,
+                masks.intensity_mask.array,
+            )
+        return MorphologicalFeatures(spacing).calculate_features(
+            masks.morphological_mask.array,
+            masks.intensity_mask.array,
+            include_correlation=bool(selected & correlation_names),
         )

--- a/zrad/radiomics/morphology.py
+++ b/zrad/radiomics/morphology.py
@@ -1,11 +1,33 @@
+import math
+
 import numpy as np
+from scipy.fft import irfftn, next_fast_len, rfftn
 from scipy.spatial import ConvexHull
-from scipy.spatial.distance import pdist, squareform
+from scipy.spatial.distance import cdist, pdist
 from scipy.special import legendre
 from skimage import measure
 
 from ..exceptions import DataStructureError
 from .base import BaseFeatureGroup
+
+# Algorithm-selection constants, independent of any resource-management policy.
+_CORRELATION_TINY_ROI = 256
+_CORRELATION_BLOCK_SIZE = 256
+_CORRELATION_FFT_COST_FACTOR = 2
+
+
+def _correlation_method(n, fft_shape):
+    """Choose exact spatial evaluation from valid count and padded geometry.
+
+    Keep geometry separate from evaluation: the same N and FFT shape can be
+    used by a future general extraction policy without changing either algorithm.
+    """
+    padded_size = math.prod(fft_shape)
+    pairs = n * (n - 1) // 2
+    fft_cost = _CORRELATION_FFT_COST_FACTOR * padded_size * math.log2(max(padded_size, 2))
+    if n > _CORRELATION_TINY_ROI and pairs > fft_cost:
+        return 'fft'
+    return 'blocked'
 
 
 def _pca_eigenvalues(points: np.ndarray) -> np.ndarray:
@@ -320,80 +342,116 @@ class MorphologyCorrelationFeatures:
         """
         return list(MORPHOLOGY_CORRELATION_FEATURE_NAMES)
 
-    def _valid_intensity_data(self, mask_array, image_array):
-        indices = np.argwhere(mask_array)
-        scaled_indices = indices * self.spacing
-        intensities = image_array[indices[:, 0], indices[:, 1], indices[:, 2]]
-        valid = ~np.isnan(intensities)
-        if np.sum(valid) < 2:
-            return None, None
-        return scaled_indices[valid], intensities[valid]
+    def _blocked_sums(self, coordinates, centered):
+        """Return ordered total weight, Moran numerator and Geary numerator."""
+        points = coordinates * np.asarray(self.spacing, dtype=np.float64)
+        n = len(centered)
+        total_weight = moran_numerator = geary_numerator = 0.0
+        block = _CORRELATION_BLOCK_SIZE
+        for i in range(0, n, block):
+            zi = centered[i : i + block]
+            for j in range(i, n, block):
+                zj = centered[j : j + block]
+                weights = cdist(points[i : i + block], points[j : j + block])
+                if i == j:
+                    np.fill_diagonal(weights, np.inf)
+                np.reciprocal(weights, out=weights)
+                multiplicity = 1 if i == j else 2
+                total_weight += multiplicity * weights.sum()
+                moran_numerator += multiplicity * np.einsum('i,ij,j->', zi, weights, zj)
+                differences = zi[:, None] - zj[None, :]
+                np.square(differences, out=differences)
+                geary_numerator += multiplicity * np.einsum('ij,ij->', weights, differences)
+        return total_weight, moran_numerator, geary_numerator
 
-    def _calc_moran_i(self, mask_array, image_array):
-        scaled_indices, intensities = self._valid_intensity_data(mask_array, image_array)
-        if scaled_indices is None:
-            return np.nan
+    def _fft_sums(self, coordinates, centered, shape, fft_shape):
+        """Joint hybrid convolution/Parseval sums, with full inverse-distance weights.
 
-        n = len(intensities)
-        mu = np.mean(intensities)
-        distances = squareform(pdist(scaled_indices))
-        weights = np.zeros_like(distances)
-        nonzero_mask = distances > 0
-        if np.any(distances[nonzero_mask] == 0):
-            raise DataStructureError("There is a zero distance in Moran I.")
-        weights[nonzero_mask] = 1.0 / distances[nonzero_mask]
-        s0 = np.sum(weights)
-        diff = intensities - mu
-        diff_outer = np.outer(diff, diff)
-        numerator = np.sum(weights * diff_outer)
-        denominator = np.sum(diff**2)
-        if denominator == 0:
-            raise DataStructureError("There determinator is zero in Moran I.")
-        return (n / s0) * (numerator / denominator)
+        Padding to at least 2L-1 preserves all ROI displacements without wraparound.
+        Only the mask convolution is inverted: S0 = sum(m * (k*m)),
+        B = sum(z**2 * (k*m)), A = sum(K * abs(FFT(z))**2) / P.
+        Symmetry gives the ordered Geary numerator G = 2(B-A).
+        """
+        axes = []
+        for length, spacing in zip(fft_shape, self.spacing):
+            offsets = np.arange(length, dtype=np.float64)
+            axes.append((np.minimum(offsets, length - offsets) * spacing) ** 2)
+        kernel = axes[0][:, None, None] + axes[1][None, :, None] + axes[2][None, None, :]
+        kernel[0, 0, 0] = np.inf
+        np.sqrt(kernel, out=kernel)
+        np.reciprocal(kernel, out=kernel)
+        # The wrapped kernel is real and even; retain only its real spectrum.
+        kernel_spectrum = rfftn(kernel, workers=1).real.copy()
+        del kernel
 
-    def _calc_geary_c(self, mask_array, image_array):
-        scaled_indices, intensities = self._valid_intensity_data(mask_array, image_array)
-        if scaled_indices is None:
-            return np.nan
+        indices = tuple(coordinates.T)
+        grid = np.zeros(shape, dtype=np.float64)
+        grid[indices] = 1
+        spectrum = rfftn(grid, s=fft_shape, workers=1)
+        spectrum *= kernel_spectrum
+        degrees = irfftn(spectrum, s=fft_shape, overwrite_x=True, workers=1)[indices]
+        total_weight = degrees.sum()
+        degree_square_sum = np.sum(centered * centered * degrees)
+        del degrees, spectrum
 
-        n = len(intensities)
-        mu = np.mean(intensities)
-        distances = squareform(pdist(scaled_indices))
-        weights = np.zeros_like(distances)
-        nonzero_mask = distances > 0
-        if np.any(distances[nonzero_mask] == 0):
-            raise DataStructureError("There is a zero distance in Geary C.")
-        weights[nonzero_mask] = 1.0 / distances[nonzero_mask]
-        s0 = np.sum(weights)
-        diff_matrix = np.subtract.outer(intensities, intensities)
-        squared_diff = diff_matrix**2
-        numerator = np.sum(weights * squared_diff)
-        denominator = np.sum((intensities - mu) ** 2)
-        if denominator == 0:
-            raise DataStructureError("There determinator is zero in Geary C.")
-        return ((n - 1) / (2 * s0)) * (numerator / denominator)
+        grid[indices] = centered
+        spectrum = rfftn(grid, s=fft_shape, workers=1)
+        # rFFT omits negative frequencies on the last axis. DC and, for an
+        # even transform length, Nyquist occur once; interior frequencies twice.
+        multiplicities = np.full(spectrum.shape[-1], 2.0)
+        multiplicities[0] = 1
+        if fft_shape[-1] % 2 == 0:
+            multiplicities[-1] = 1
+        moran_numerator = 0.0
+        for plane, kernel_plane in zip(spectrum, kernel_spectrum):
+            power = plane.real**2 + plane.imag**2
+            moran_numerator += np.einsum('ij,ij,j->', power, kernel_plane, multiplicities)
+        moran_numerator /= math.prod(fft_shape)
+        return total_weight, moran_numerator, 2 * (degree_square_sum - moran_numerator)
 
     def calculate_features(self, mask_array, image_array):
-        """Calculate morphology correlation features for prepared mask and intensity arrays.
+        """Calculate both features jointly from aligned 3D mask and intensity arrays.
 
-        Parameters
-        ----------
-        mask_array : numpy.ndarray
-            Prepared binary ROI mask array.
-        image_array : numpy.ndarray
-            Prepared intensity image aligned with ``mask_array`` where voxels
-            outside the ROI can be represented by ``NaN``.
-
-        Returns
-        -------
-        dict
-            Mapping of morphology correlation feature names to calculated values.
+        Nonzero mask voxels with non-NaN intensities form the population. Raw
+        intensities are converted to float64; texture discretization is not used.
+        Uses exact hybrid FFT/Parseval or blocked pair sums according to valid
+        voxel count and padded bounding-box geometry.
         """
         mask_array = np.asarray(mask_array)
         image_array = np.asarray(image_array)
+        if mask_array.ndim != 3 or image_array.shape != mask_array.shape:
+            raise ValueError('Morphology correlation requires aligned 3D mask and intensity arrays.')
+        spacing = np.asarray(self.spacing, dtype=np.float64)
+        if spacing.shape != (3,) or not np.all(np.isfinite(spacing) & (spacing > 0)):
+            raise ValueError('Morphology correlation requires three positive finite voxel spacings.')
+        coordinates = np.argwhere((mask_array != 0) & ~np.isnan(image_array))
+        values = np.asarray(image_array[tuple(coordinates.T)], dtype=np.float64)
+        n = len(values)
+        if n < 2 or not np.all(np.isfinite(values)):
+            # Infinity was not excluded by the old NaN-only population rule;
+            # it propagated to NaN results. Preserve that behavior explicitly.
+            return dict.fromkeys(MORPHOLOGY_CORRELATION_FEATURE_NAMES, np.nan)
+        centered = values - np.mean(values)
+        variance_sum = np.sum(centered**2)
+        del values
+        if variance_sum == 0:
+            raise DataStructureError("Moran's I and Geary's C are undefined for constant intensities.")
+        coordinates -= coordinates.min(axis=0)
+        shape = tuple(int(value) + 1 for value in coordinates.max(axis=0))
+        fft_shape = tuple(next_fast_len(2 * length - 1) for length in shape)
+        method = _correlation_method(n, fft_shape)
+        if method == 'fft':
+            total_weight, moran_numerator, geary_numerator = self._fft_sums(
+                coordinates,
+                centered,
+                shape,
+                fft_shape,
+            )
+        else:
+            total_weight, moran_numerator, geary_numerator = self._blocked_sums(coordinates, centered)
         return {
-            'morph_moran_i': self._calc_moran_i(mask_array, image_array),
-            'morph_geary_c': self._calc_geary_c(mask_array, image_array),
+            'morph_moran_i': (n / total_weight) * (moran_numerator / variance_sum),
+            'morph_geary_c': ((n - 1) / (2 * total_weight)) * (geary_numerator / variance_sum),
         }
 
 

--- a/zrad/radiomics/morphology.py
+++ b/zrad/radiomics/morphology.py
@@ -437,6 +437,10 @@ class MorphologyCorrelationFeatures:
             # Infinity was not excluded by the old NaN-only population rule;
             # it propagated to NaN results. Preserve that behavior explicitly.
             return dict.fromkeys(MORPHOLOGY_CORRELATION_FEATURE_NAMES, np.nan)
+        # A rounded mean can differ from every value in a constant float array.
+        # Test equality directly; a tolerance would discard real low contrast.
+        if np.all(values == values[0]):
+            return dict.fromkeys(MORPHOLOGY_CORRELATION_FEATURE_NAMES, np.nan)
         centered = values - np.mean(values)
         variance_sum = np.sum(centered**2)
         del values

--- a/zrad/radiomics/morphology.py
+++ b/zrad/radiomics/morphology.py
@@ -301,6 +301,8 @@ class MorphologicalFeatures:
             area_density_ch,
             integrated_intensity,
         ]
+        correlation = MorphologyCorrelationFeatures(self.spacing).calculate_features(mask_array, image_array)
+        values.extend(correlation[name] for name in MORPHOLOGY_CORRELATION_FEATURE_NAMES)
         return dict(zip(MORPHOLOGY_FEATURE_NAMES, values))
 
 
@@ -308,8 +310,8 @@ class MorphologyCorrelationFeatures:
     """Spatial autocorrelation descriptors for a 3D region of interest.
 
     Moran's I and Geary's C summarize how intensity values vary with physical
-    distance between ROI voxels. They are optional morphology-related features
-    and require both a morphology mask and aligned intensity image.
+    distance between ROI voxels. They are morphological features and require both a morphology mask
+    and aligned intensity image.
 
     Parameters
     ----------
@@ -479,6 +481,8 @@ MORPHOLOGY_FEATURE_NAMES = (
     'morph_vol_dens_conv_hull',
     'morph_area_dens_conv_hull',
     'morph_integ_int',
+    'morph_moran_i',
+    'morph_geary_c',
 )
 
 
@@ -507,33 +511,6 @@ class MorphologyFeatureGroup(BaseFeatureGroup):
     def calculate(self, context, prepared_data):
         masks = prepared_data.require_base_masks()
         morphology = MorphologicalFeatures(
-            masks.morphological_mask.spacing[::-1],
-        )
-        return morphology.calculate_features(
-            masks.morphological_mask.array,
-            masks.intensity_mask.array,
-        )
-
-
-class MorphologyCorrelationFeatureGroup(BaseFeatureGroup):
-    family = 'morphology_correlation'
-    requirements = frozenset({'base_masks'})
-
-    def supports(self, context):
-        return not context.is_slice_2d
-
-    def default_enabled(self, context):
-        return False
-
-    def output_names(self, context):
-        return MORPHOLOGY_CORRELATION_FEATURE_NAMES
-
-    def feature_aliases(self, context):
-        return {name: name for name in self.output_names(context)}
-
-    def calculate(self, context, prepared_data):
-        masks = prepared_data.require_base_masks()
-        morphology = MorphologyCorrelationFeatures(
             masks.morphological_mask.spacing[::-1],
         )
         return morphology.calculate_features(

--- a/zrad/radiomics/morphology.py
+++ b/zrad/radiomics/morphology.py
@@ -417,7 +417,8 @@ class MorphologyCorrelationFeatures:
         Nonzero mask voxels with non-NaN intensities form the population. Raw
         intensities are converted to float64; texture discretization is not used.
         Uses exact hybrid FFT/Parseval or blocked pair sums according to valid
-        voxel count and padded bounding-box geometry.
+        voxel count and padded bounding-box geometry. Fewer than two observations,
+        nonfinite intensities, or zero intensity variance yield NaN for both features.
         """
         mask_array = np.asarray(mask_array)
         image_array = np.asarray(image_array)
@@ -437,7 +438,8 @@ class MorphologyCorrelationFeatures:
         variance_sum = np.sum(centered**2)
         del values
         if variance_sum == 0:
-            raise DataStructureError("Moran's I and Geary's C are undefined for constant intensities.")
+            # Undefined statistics must not discard other valid morphology results.
+            return dict.fromkeys(MORPHOLOGY_CORRELATION_FEATURE_NAMES, np.nan)
         coordinates -= coordinates.min(axis=0)
         shape = tuple(int(value) + 1 for value in coordinates.max(axis=0))
         fft_shape = tuple(next_fast_len(2 * length - 1) for length in shape)


### PR DESCRIPTION
Moran’s I and Geary’s C previously constructed dense pairwise matrices, making large CT ROIs impractical to process. Both measures now share an exact calculation using hybrid FFT/Parseval sums or blocked SciPy pair sums, selected automatically from voxel count and bounding-box geometry.

Both features are included in standard morphology extraction and default API/GUI output. The dedicated `morphology_correlation` family is removed; individual feature-name selection remains available.

- Preserves full inverse physical-distance weights without neighborhood truncation or sampling.
- Introduces no resource caps or additional dependencies.
- Updates the user guide and API documentation.

Validation covers direct numerical comparisons, anisotropic spacing, irregular masks, re-segmentation, edge cases, feature selection, and GUI CSV output. Both calculation paths pass IBSI-I reference tolerances for configurations A–E. All 173 relevant tests passed, along with lint and whitespace checks.